### PR TITLE
do not error out if there are no steps

### DIFF
--- a/lib/rainforest/cli.rb
+++ b/lib/rainforest/cli.rb
@@ -85,7 +85,7 @@ module Rainforest
       response = post(API_URL + '/runs', post_opts)
 
       if response['error']
-        if response['error'].include? "There are no steps in this run"
+        if !response['error'].index("There are no steps in this run").nil?
           logger.error "Error starting your run: #{response['error']}"
         else
           logger.fatal "Error starting your run: #{response['error']}"


### PR DESCRIPTION
Hey there.  This may be very specific to how I am trying to set up rainforest, but I figure a PR never hurts anyone ;)  

I don't consider no steps to be a fatal error.  This is because I am trying to match up the git branch name with rainforest tags.  So if the tag does not exist, then no problem, it will run specs with the "main" tag.  
