### PR TITLE
Improved usability; display help by default

### DIFF
--- a/lib/rainforest/cli.rb
+++ b/lib/rainforest/cli.rb
@@ -12,7 +12,8 @@ module Rainforest
     
     def self.start(args)
       @options = OptionParser.new(args)
-
+      OptionParser.new(['--help']) if args.size == 0
+      
       unless @options.token
         logger.fatal "You must pass your API token using: --token TOKEN"
         exit 2

--- a/lib/rainforest/cli/options.rb
+++ b/lib/rainforest/cli/options.rb
@@ -66,6 +66,11 @@ module Rainforest
           opts.on("--custom-url URL", String, "Use a custom url for this run. You will need to specify a site_id too for this to work.") do |value|
             @custom_url = value
           end
+          
+          opts.on_tail("--help", "Display help message and exit") do |value|
+            puts opts
+            exit 0
+          end
         end.parse!(@args)
 
         @command = @args.shift


### PR DESCRIPTION
Changed the default response to displaying the help if no options are specified versus displaying the cryptic "You must pass your API token using: --token TOKEN" error, and adding an explicit --help. 