### PR TITLE
List

### DIFF
--- a/lib/rainforest/cli.rb
+++ b/lib/rainforest/cli.rb
@@ -35,6 +35,16 @@ module Rainforest
         tp response, "id", "name"
         exit 0
       end
+      
+      if @options.list_runs
+        url_append = @options.list_runs == true ? '/runs.json' : '/runs.json?state=' + @options.list_runs
+        response = get(API_URL + url_append)
+        tp.set :max_width, 60
+        response.map { |test| test['tests'] = test['tests'].map{|b| b = b['id']}.join(', ')}
+        response.map { |test| test['browsers'] = test['browsers'].map{|b| b['state'] == 'enabled' ? b = b['name'] + ', ' : b = []}.join()[0..-3] }
+        tp response, "id", "created_at", "tests", "browsers", "state", "result"
+        exit 0
+      end
 
       if @options.custom_url && @options.site_id.nil?
         logger.fatal "The site-id and custom-url options are both required."

--- a/lib/rainforest/cli/options.rb
+++ b/lib/rainforest/cli/options.rb
@@ -11,7 +11,8 @@ module Rainforest
 
     class OptionParser
       attr_reader :command, :token, :tags, :conflict, :browsers, :site_id,
-                  :import_file_name, :import_name, :custom_url
+                  :import_file_name, :import_name, :custom_url, :list_tests,
+                  :list_sites
 
       VALID_BROWSERS = %w{chrome firefox safari ie8 ie9}.freeze
 
@@ -65,6 +66,14 @@ module Rainforest
 
           opts.on("--custom-url URL", String, "Use a custom url for this run. You will need to specify a site_id too for this to work.") do |value|
             @custom_url = value
+          end
+
+          opts.on("--list-tests", String, "List client's tests and exit") do |value|
+            @list_tests = true
+          end
+
+          opts.on("--list-sites", String, "List client's sites and exit") do |value|
+            @list_sites = true
           end
         end.parse!(@args)
 

--- a/lib/rainforest/cli/options.rb
+++ b/lib/rainforest/cli/options.rb
@@ -12,7 +12,7 @@ module Rainforest
     class OptionParser
       attr_reader :command, :token, :tags, :conflict, :browsers, :site_id,
                   :import_file_name, :import_name, :custom_url, :list_tests,
-                  :list_sites
+                  :list_sites, :list_runs
 
       VALID_BROWSERS = %w{chrome firefox safari ie8 ie9}.freeze
 
@@ -68,12 +68,16 @@ module Rainforest
             @custom_url = value
           end
 
-          opts.on("--list-tests", String, "List client's tests and exit") do |value|
+          opts.on("--list-tests", String, "List tests and exit") do |value|
             @list_tests = true
           end
 
-          opts.on("--list-sites", String, "List client's sites and exit") do |value|
+          opts.on("--list-sites", String, "List sites and exit") do |value|
             @list_sites = true
+          end
+
+          opts.on("--list-runs [STATE]", String, "List all runs [with optional STATE] and exit") do |value|
+            @list_runs = value ? value : true
           end
         end.parse!(@args)
 

--- a/rainforest-cli.gemspec
+++ b/rainforest-cli.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "httparty"
   spec.add_dependency "parallel"
   spec.add_dependency "ruby-progressbar"
+  spec.add_dependency "table_print"
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
   


### PR DESCRIPTION
Added ability to list tests, sites, and runs. Includes table_print gem dependency. 
![screenshot from 2014-12-21 13 00 06](https://cloud.githubusercontent.com/assets/914030/5519290/a615edf8-8911-11e4-8dce-93649aa4cdcc.png)

Note: this merge and the test merge (for launching runs with specific test ids and aborting specific runs) require special merging as lines 14 and 15 of lib/rainforest/cli/options.rb conflict.