### PR TITLE
Run by test id and abort running tests.

### DIFF
--- a/lib/rainforest/cli.rb
+++ b/lib/rainforest/cli.rb
@@ -36,6 +36,26 @@ module Rainforest
         exit 2
       end
 
+      if @options.abort
+        if @options.run_ids.nil?
+          logger.fatal "You must pass a list of runs to abort"
+          exit 2
+        end
+        
+        @options.run_ids.each do |runid|
+          logger.debug "URL: " + API_URL + '/runs/' + runid.to_s + '.json'
+          logger.info "Issuing delete"
+          response = delete(API_URL + '/runs/' + runid.to_s + '.json')
+          
+          unless response['error'].nil?
+            logger.fatal "Error starting your run: #{response['error']}"
+            exit 1
+          end
+          
+          return
+        end
+      end
+      
       post_opts = {}
 
       if @options.git_trigger?

--- a/lib/rainforest/cli/options.rb
+++ b/lib/rainforest/cli/options.rb
@@ -11,7 +11,8 @@ module Rainforest
 
     class OptionParser
       attr_reader :command, :token, :tags, :conflict, :browsers, :site_id,
-                  :import_file_name, :import_name, :custom_url, :tests
+                  :import_file_name, :import_name, :custom_url, :tests, 
+                  :abort, :run_ids
 
       VALID_BROWSERS = %w{chrome firefox safari ie8 ie9}.freeze
 
@@ -19,6 +20,7 @@ module Rainforest
         @args = args.dup
         @tags = []
         @tests = []
+        @run_ids = []
         @browsers = nil
 
         @parsed = ::OptionParser.new do |opts|
@@ -52,6 +54,11 @@ module Rainforest
 
           opts.on("--tests TEST[,TEST]", String, "A set of test ids to run") do |value|
             @tests << value
+          end
+
+          opts.on("--abort RUN[,RUN]", String, "A set of runs to abort") do |value|
+            @abort = true
+            @run_ids << value
           end
 
           opts.on("--browsers LIST", "Run against the specified browsers") do |value|


### PR DESCRIPTION
Adds the ability to start tests by listing ids with the --tests option as specified by a blank POST request to https://app.rainforestqa.com/api/1/runs.json:
    {
      "error": "You must specify the tags or tests parameter"
    }

Also adds the ability to abort runs by run id. 

Note: this merge and the list merge (for listing tests, sites, and runs) require special merging as lines 14 and 15 of lib/rainforest/cli/options.rb conflict.
