### PR TITLE
Retrying on Timeouts and HTTP errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## 1.2.1 - 19th February 2016
 - Fixed a bug where uploading was stuck in an infinite loop if an embedded id did not exist (7b02b2f66dbd47098a7c1d5f79bc60a0cbe8984f, @epaulet)
 - Fixed a bug that occurred when specifying a nested test folder without creating parent folders first (6c1b0e02c858f9d9c264e771f964b3e1a4ea8c7e, @epaulet)
+- Add retries on API calls so that minor interruptions do not cancel Rainforest builds.
+(98021337a3fbbf16c7cd858bbec5d925fb86c939, @epaulet)
 
 ## 1.2.0 - 8th February 2016
 - Add support for embedded tests.

--- a/lib/rainforest/cli.rb
+++ b/lib/rainforest/cli.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 require 'erb'
-require 'httparty'
 require 'json'
 require 'logger'
 require 'rainforest/cli/version'

--- a/lib/rainforest/cli.rb
+++ b/lib/rainforest/cli.rb
@@ -1,4 +1,8 @@
 # frozen_string_literal: true
+require 'erb'
+require 'httparty'
+require 'json'
+require 'logger'
 require 'rainforest/cli/version'
 require 'rainforest/cli/constants'
 require 'rainforest/cli/options'
@@ -12,10 +16,6 @@ require 'rainforest/cli/remote_tests'
 require 'rainforest/cli/validator'
 require 'rainforest/cli/test_importer'
 require 'rainforest/cli/uploader'
-require 'erb'
-require 'httparty'
-require 'json'
-require 'logger'
 
 module RainforestCli
   def self.start(args)

--- a/lib/rainforest/cli/csv_importer.rb
+++ b/lib/rainforest/cli/csv_importer.rb
@@ -1,7 +1,6 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 require 'csv'
-require 'httparty'
 require 'parallel'
 require 'ruby-progressbar'
 

--- a/lib/rainforest/cli/http_client.rb
+++ b/lib/rainforest/cli/http_client.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require 'httparty'
 require 'http/exceptions'
 
 module RainforestCli

--- a/lib/rainforest/cli/runner.rb
+++ b/lib/rainforest/cli/runner.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 module RainforestCli
   class Runner
+    MAX_EXCEPTIONS_UNTIL_RUN_COMPLETION = ENV.fetch('RAINFOREST_EXCEPTION_TOLERANCE', 5).to_i
+
     attr_reader :options, :client
 
     def initialize(options)
@@ -38,7 +40,7 @@ module RainforestCli
       running = true
       while running
         Kernel.sleep 5
-        response = client.get("/runs/#{run_id}")
+        response = client.get("/runs/#{run_id}", {}, max_exceptions: MAX_EXCEPTIONS_UNTIL_RUN_COMPLETION)
         if response
           state_details = response.fetch('state_details')
           unless state_details.fetch('is_final_state')

--- a/lib/rainforest/cli/runner.rb
+++ b/lib/rainforest/cli/runner.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 module RainforestCli
   class Runner
-    MAX_EXCEPTIONS_UNTIL_RUN_COMPLETION = ENV.fetch('RAINFOREST_EXCEPTION_TOLERANCE', 5).to_i
-
     attr_reader :options, :client
 
     def initialize(options)
@@ -40,7 +38,7 @@ module RainforestCli
       running = true
       while running
         Kernel.sleep 5
-        response = client.get("/runs/#{run_id}", {}, max_exceptions: MAX_EXCEPTIONS_UNTIL_RUN_COMPLETION)
+        response = client.get("/runs/#{run_id}", {}, retries_on_failures: true)
         if response
           state_details = response.fetch('state_details')
           unless state_details.fetch('is_final_state')

--- a/rainforest-cli.gemspec
+++ b/rainforest-cli.gemspec
@@ -20,9 +20,10 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'httparty', '~> 0.13.7'
-  spec.add_dependency 'parallel', '~> 1.6.1'
-  spec.add_dependency 'ruby-progressbar', '~> 1.7.5'
-  spec.add_dependency 'rainforest', '~> 2.1.0'
+  spec.add_dependency 'parallel', '~> 1.6', '>= 1.6.1'
+  spec.add_dependency 'ruby-progressbar', '~> 1.7', '>= 1.7.5'
+  spec.add_dependency 'rainforest', '~> 2.1', '>= 2.1.0'
+  spec.add_dependency 'http-exceptions', '~> 0.0', '>= 0.0.4'
   spec.add_development_dependency 'bundler', '~> 1.3'
-  spec.add_development_dependency 'rake', '~> 10.4.2'
+  spec.add_development_dependency 'rake', '~> 10.4', '>= 10.4.2'
 end

--- a/spec/http_client_spec.rb
+++ b/spec/http_client_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+describe RainforestCli::HttpClient do
+  subject { described_class.new({ token: 'foo' }) }
+
+  describe '#get' do
+    describe 'maximum tolerated exceptions' do
+      let(:url) { 'http://some.url.com' }
+
+      before do
+        allow(HTTParty).to receive(:get).and_raise(SocketError)
+      end
+
+      context 'max exceptions == 0' do
+        it 'raises the error on the first exception' do
+          expect(HTTParty).to receive(:get).once
+          expect { subject.get(url, {}, max_exceptions: 0) }.to raise_error(Http::Exceptions::HttpException)
+        end
+      end
+
+      context 'max exceptions > 0' do
+        it 'raises an error after (max_exceptions + 1) tries' do
+          expect(HTTParty).to receive(:get).exactly(4).times
+          expect { subject.get(url, {}, max_exceptions: 3) }.to raise_error(Http::Exceptions::HttpException)
+        end
+      end
+
+      context 'get a result before reaching max exceptions' do
+        let(:response) { instance_double('HTTParty::Response', code: 200, body: {foo: :bar}.to_json) }
+
+        before do
+          expect(HTTParty).to receive(:get).exactly(3).times.and_raise(SocketError).ordered
+          expect(HTTParty).to receive(:get).once.and_return(response).ordered
+        end
+
+        it 'does not raise an error but returns a value instead' do
+          expect(subject.get(url, {}, max_exceptions: 3)).to_not be_nil
+        end
+      end
+    end
+  end
+end

--- a/spec/http_client_spec.rb
+++ b/spec/http_client_spec.rb
@@ -24,7 +24,7 @@ describe RainforestCli::HttpClient do
         end
       end
 
-      context 'get a result before reaching max exceptions' do
+      context 'get a result before exceeding max exceptions' do
         let(:response) { instance_double('HTTParty::Response', code: 200, body: {foo: :bar}.to_json) }
 
         before do


### PR DESCRIPTION
fixes #58 

Also fixes some more dependency warnings when building gem.

```
$ gem build rainforest-cli.gemspec
WARNING:  description and summary are identical
WARNING:  pessimistic dependency on parallel (~> 1.6.1) may be overly strict
  if parallel is semantically versioned, use:
    add_runtime_dependency 'parallel', '~> 1.6', '>= 1.6.1'
WARNING:  pessimistic dependency on ruby-progressbar (~> 1.7.5) may be overly strict
  if ruby-progressbar is semantically versioned, use:
    add_runtime_dependency 'ruby-progressbar', '~> 1.7', '>= 1.7.5'
WARNING:  pessimistic dependency on rainforest (~> 2.1.0) may be overly strict
  if rainforest is semantically versioned, use:
    add_runtime_dependency 'rainforest', '~> 2.1', '>= 2.1.0'
WARNING:  pessimistic dependency on rake (~> 10.4.2, development) may be overly strict
  if rake is semantically versioned, use:
    add_development_dependency 'rake', '~> 10.4', '>= 10.4.2'
WARNING:  See http://guides.rubygems.org/specification-reference/ for help
  Successfully built RubyGem
  Name: rainforest-cli
  Version: 1.2.1
  File: rainforest-cli-1.2.1.gem
```