### PR TITLE
Remove 'ro' tag in favor of source 'rainforest-cli'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## 1.2.1 - 19th February 2016
 - Fixed a bug where uploading was stuck in an infinite loop if an embedded id did not exist (7b02b2f66dbd47098a7c1d5f79bc60a0cbe8984f, @epaulet)
 - Fixed a bug that occurred when specifying a nested test folder without creating parent folders first (6c1b0e02c858f9d9c264e771f964b3e1a4ea8c7e, @epaulet)
+- Removed 'ro' tag and use 'rainforest-cli' as the test's source instead.
+(10864a7e054d4c869f6a345608b2d1c1c0925fe8, @epaulet)
 
 ## 1.2.0 - 8th February 2016
 - Add support for embedded tests.

--- a/lib/rainforest/cli/uploader.rb
+++ b/lib/rainforest/cli/uploader.rb
@@ -83,7 +83,8 @@ class RainforestCli::Uploader
       start_uri: rfml_test.start_uri || '/',
       title: rfml_test.title,
       description: rfml_test.description,
-      tags: (['ro'] + rfml_test.tags).uniq,
+      source: 'rainforest-cli',
+      tags: rfml_test.tags.uniq,
       rfml_id: rfml_test.rfml_id
     }
 

--- a/spec/rainforest-example/example_test.rfml
+++ b/spec/rainforest-example/example_test.rfml
@@ -1,6 +1,7 @@
 #! example_test (Test ID - only edit if this test has not yet been uploaded)
 # title: Example Test
-# start_uri: /
+# tags: foo,bar,baz
+# start_uri: /start_uri
 
 This is a step action.
 This is a question?

--- a/spec/uploader_spec.rb
+++ b/spec/uploader_spec.rb
@@ -1,10 +1,12 @@
 # frozen_string_literal: true
 describe RainforestCli::Uploader do
-  let(:test_directory) { File.expand_path(File.join(__FILE__, '../validation-examples/correct_embeds')) }
   let(:options) { instance_double('RainforestCli::Options', token: 'foo', test_folder: test_directory) }
+  let(:progress_bar_double) { double('ProgressBar') }
   subject { described_class.new(options) }
 
   before do
+    allow(ProgressBar).to receive(:create).and_return(progress_bar_double)
+    allow(progress_bar_double).to receive(:increment)
     allow_any_instance_of(RainforestCli::Validator).to receive(:validate_with_exception!)
     allow_any_instance_of(RainforestCli::RemoteTests).to receive(:primary_key_dictionary)
       .and_return({})
@@ -12,12 +14,10 @@ describe RainforestCli::Uploader do
 
   describe '#upload' do
     context 'with new tests' do
-      let(:progress_bar_double) { double('ProgressBar') }
+      let(:test_directory) { File.expand_path(File.join(__FILE__, '../validation-examples/correct_embeds')) }
       let(:rf_test_double) { instance_double('Rainforest::Test', id: 123) }
 
       before do
-        allow(ProgressBar).to receive(:create).and_return(progress_bar_double)
-        allow(progress_bar_double).to receive(:increment)
         allow(subject).to receive(:upload_test)
       end
 
@@ -26,6 +26,29 @@ describe RainforestCli::Uploader do
           .and_return(rf_test_double).twice
         subject.upload
       end
+    end
+  end
+
+  describe 'uploaded test object' do
+    let(:test_directory) { File.expand_path(File.join(__FILE__, '../rainforest-example')) }
+    let(:test_double) { instance_double('Rainforest::Test', id: 123) }
+
+    before do
+      allow(Rainforest::Test).to receive(:create).and_return(test_double)
+    end
+
+    it 'contains the correct attributes' do
+      expect(Rainforest::Test).to receive(:update) do |_id, test_attrs|
+        expect(test_attrs).to include({
+                                        start_uri: '/start_uri',
+                                        title: 'Example Test',
+                                        source: 'rainforest-cli',
+                                        tags: ['foo', 'bar', 'baz'],
+                                        rfml_id: 'example_test'
+                                      })
+      end
+
+      subject.upload
     end
   end
 end


### PR DESCRIPTION
fixes #61

Do not merge until backend change is shipped first.

Edit: backend shipped.