### PR TITLE
get token from environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,22 +25,24 @@ gem "rainforest-cli", require: false
 ## Basic Usage
 To use the cli client, you'll need your API token from a test settings page from inside [Rainforest](https://app.rainforestqa.com/).
 
+You can either pass the token with `--token YOUR_TOKEN_HERE` CLI option, or put it in the `RAINFOREST_API_TOKEN` environment variable.
+
 Run all of your tests
 
 ```bash
-rainforest run all --token YOUR_TOKEN_HERE
+rainforest run all
 ```
 
 Run all in the foreground and report
 
 ```bash
-rainforest run all --fg --token YOUR_TOKEN_HERE
+rainforest run all --fg
 ```
 
 Run all tests with tag 'run-me' and abort previous in-progress runs.
 
 ```bash
-rainforest run --tag run-me --fg --conflict abort --token YOUR_TOKEN_HERE
+rainforest run --tag run-me --fg --conflict abort
 ```
 
 Create new Rainforest test in RFML format (Rainforest Markup Language).
@@ -52,7 +54,7 @@ rainforest new
 Upload tests to Rainforest
 
 ```bash
-rainforest upload --token YOUR_TOKEN_HERE
+rainforest upload
 ```
 
 Export tests from Rainforest
@@ -64,8 +66,7 @@ rainforest export --token YOUR_TOKEN_HERE
 
 ### General
 
-Required:
-- `--token <your-rainforest-token>` - you must supply your token (get it from any tests API tab)
+- `--token <your-rainforest-token>` - supply your token (get it from any tests API tab), if not set in `RAINFOREST_API_TOKEN` environment variable
 
 
 ### Running Tests

--- a/lib/rainforest/cli/options.rb
+++ b/lib/rainforest/cli/options.rb
@@ -47,6 +47,7 @@ module RainforestCli
       @tags = []
       @browsers = nil
       @debug = false
+      @token = ENV['RAINFOREST_API_TOKEN']
 
       # NOTE: Disabling line length cop to allow for consistency of syntax
       # rubocop:disable Metrics/LineLength

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -173,6 +173,19 @@ describe RainforestCli do
       end
     end
 
+    context 'with token from env' do
+      let(:params) { %w(run) }
+
+      it 'starts the run without error' do
+        expect_any_instance_of(http_client).to receive(:post).with(
+          '/runs',
+          { tests: [] }
+        ).and_return({})
+        allow(ENV).to receive(:[]).with('RAINFOREST_API_TOKEN').and_return('x')
+        described_class.start(params)
+      end
+    end
+
     context 'a simple run' do
       before do
         allow_any_instance_of(http_client).to receive(:post).and_return('id' => 1)


### PR DESCRIPTION
Rainforest token, if not given with `--token`, is fetched from the `RAINFOREST_API_TOKEN` environment variable.