### PR TITLE
Remove Circlemator

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,6 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'rf-stylez'
-gem 'circlemator', require: false
 
 group :test do
   gem 'rspec', '~> 3.4.0'

--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,0 @@
-test:
-  pre:
-    - bundle exec circlemator style-check --base-branch=master


### PR DESCRIPTION
It appears to be breaking PRs from people without write access. GitHub does not
have any way to have comment-only permission so Rainforest bot cannot post
comments in PRs.