### PR TITLE
Hotfix: add rainforest-cli attribute for empty tests

### DIFF
--- a/lib/rainforest/cli/uploader.rb
+++ b/lib/rainforest/cli/uploader.rb
@@ -51,7 +51,8 @@ class RainforestCli::Uploader
     test_obj = {
       title: rfml_test.title,
       start_uri: rfml_test.start_uri,
-      rfml_id: rfml_test.rfml_id
+      rfml_id: rfml_test.rfml_id,
+      source: 'rainforest-cli'
     }
     rf_test = Rainforest::Test.create(test_obj)
 

--- a/spec/uploader_spec.rb
+++ b/spec/uploader_spec.rb
@@ -19,7 +19,7 @@ describe RainforestCli::Uploader do
       end
 
       it 'creates uploads the new tests with no steps' do
-        expect(Rainforest::Test).to receive(:create).with(hash_including(:title, :start_uri, :rfml_id))
+        expect(Rainforest::Test).to receive(:create).with(hash_including(:title, :start_uri, :rfml_id, :source))
           .and_return(rf_test_double).twice
         subject.upload
       end


### PR DESCRIPTION
The flag makes sure the test is read-only, which is important in case something fails later along in the upload process.