### PR TITLE
Add timeout exception handling to HttpClient::post

### DIFF
--- a/lib/rainforest/cli/http_client.rb
+++ b/lib/rainforest/cli/http_client.rb
@@ -23,14 +23,16 @@ module RainforestCli
       JSON.parse(response.body)
     end
 
-    def post(url, body = {})
-      response = HTTParty.post make_url(url), {
-        body: body,
-        headers: headers,
-        verify: false
-      }
+    def post(url, body = {}, options = {})
+      wrap_exceptions(options[:retries_on_failures]) do
+        response = HTTParty.post make_url(url), {
+          body: body,
+          headers: headers,
+          verify: false
+        }
 
-      JSON.parse(response.body)
+        return JSON.parse(response.body)
+      end
     end
 
     def get(url, body = {}, options = {})

--- a/lib/rainforest/cli/runner.rb
+++ b/lib/rainforest/cli/runner.rb
@@ -19,7 +19,7 @@ module RainforestCli
       logger.debug "POST options: #{post_opts.inspect}"
       logger.info 'Issuing run'
 
-      response = client.post('/runs', post_opts)
+      response = client.post('/runs', post_opts, retries_on_failures: true)
 
       if response['error']
         logger.fatal "Error starting your run: #{response['error']}"

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -102,7 +102,7 @@ describe RainforestCli do
 
         it 'starts the run with the specified tags' do
           expect_any_instance_of(http_client).to receive(:post)
-            .with('/runs', tags: ['run-me']).and_return({})
+            .with('/runs', { tags: ['run-me'] }, { retries_on_failures: true }).and_return({})
 
           start_with_params(params, 0)
         end
@@ -116,7 +116,7 @@ describe RainforestCli do
           .with('/environments', name: 'temporary-env-for-custom-url-via-CLI', url: 'http://ad-hoc.example.com')
           .and_return({ 'id' => 333 })
 
-        expect_any_instance_of(http_client).to receive(:post).with('/runs', anything)
+        expect_any_instance_of(http_client).to receive(:post).with('/runs', anything, { retries_on_failures: true })
           .and_return({ 'id' => 1 })
 
         # This is a hack because when expecting a function to be called with
@@ -140,7 +140,8 @@ describe RainforestCli do
 
         expect_any_instance_of(http_client).to receive(:post).with(
           '/runs',
-          { tests: [], site_id: 3, environment_id: 333 }
+          { tests: [], site_id: 3, environment_id: 333 },
+          { retries_on_failures: true }
         ).and_return({})
         described_class.start(params)
       end
@@ -155,7 +156,8 @@ describe RainforestCli do
 
         expect_any_instance_of(http_client).to receive(:post).with(
           '/runs',
-          { tests: [], environment_id: 123 }
+          { tests: [], environment_id: 123 },
+          { retries_on_failures: true }
         ).and_return({})
         described_class.start(params)
       end
@@ -167,7 +169,8 @@ describe RainforestCli do
       it 'starts the run with smart folder' do
         expect_any_instance_of(http_client).to receive(:post).with(
           '/runs',
-          { smart_folder_id: 123 }
+          { smart_folder_id: 123 },
+          { retries_on_failures: true }
         ).and_return({})
         described_class.start(params)
       end
@@ -179,7 +182,8 @@ describe RainforestCli do
       it 'starts the run without error' do
         expect_any_instance_of(http_client).to receive(:post).with(
           '/runs',
-          { tests: [] }
+          { tests: [] },
+          { retries_on_failures: true }
         ).and_return({})
         allow(ENV).to receive(:[]).with('RAINFOREST_API_TOKEN').and_return('x')
         described_class.start(params)


### PR DESCRIPTION
We ran into this today when running the Rainforest CLI for the first time.  I'm not a ruby developer, but attempted to add retry support into the post method via this PR.

```
/usr/share/ruby/2.3/net/protocol.rb:158:in `rbuf_fill': Net::ReadTimeout (Net::ReadTimeout)
 from /usr/share/ruby/2.3/net/protocol.rb:136:in `readuntil'
 from /usr/share/ruby/2.3/net/protocol.rb:146:in `readline'
 from /usr/share/ruby/2.3/net/http/response.rb:40:in `read_status_line'
 from /usr/share/ruby/2.3/net/http/response.rb:29:in `read_new'
 from /usr/share/ruby/2.3/net/http.rb:1437:in `block in transport_request'
 from /usr/share/ruby/2.3/net/http.rb:1434:in `catch'
 from /usr/share/ruby/2.3/net/http.rb:1434:in `transport_request'
 from /usr/share/ruby/2.3/net/http.rb:1407:in `request'
 from /usr/share/ruby/2.3/net/http.rb:1400:in `block in request'
 from /usr/share/ruby/2.3/net/http.rb:853:in `start'
 from /usr/share/ruby/2.3/net/http.rb:1398:in `request'
 from /usr/local/share/ruby/gems/2.3/gems/httparty-0.13.7/lib/httparty/request.rb:117:in `perform'
 from /usr/local/share/ruby/gems/2.3/gems/httparty-0.13.7/lib/httparty.rb:545:in `perform_request'
 from /usr/local/share/ruby/gems/2.3/gems/httparty-0.13.7/lib/httparty.rb:492:in `post'
 from /usr/local/share/ruby/gems/2.3/gems/httparty-0.13.7/lib/httparty.rb:587:in `post'
 from /usr/local/share/ruby/gems/2.3/gems/rainforest-cli-1.4.0/lib/rainforest/cli/http_client.rb:27:in `post'
 from /usr/local/share/ruby/gems/2.3/gems/rainforest-cli-1.4.0/lib/rainforest/cli/runner.rb:22:in `run'
 from /usr/local/share/ruby/gems/2.3/gems/rainforest-cli-1.4.0/lib/rainforest/cli.rb:33:in `start'
 from /usr/local/share/ruby/gems/2.3/gems/rainforest-cli-1.4.0/bin/rainforest:7:in `<top (required)>'
 from /usr/local/bin/rainforest:23:in `load'
 from /usr/local/bin/rainforest:23:in `<main>'
```