### PR TITLE
Exporting tests with --embed-tests now keeps the redirect flag

### DIFF
--- a/lib/rainforest/cli/exporter.rb
+++ b/lib/rainforest/cli/exporter.rb
@@ -55,6 +55,7 @@ class RainforestCli::Exporter
     when 'test'
       if @options.embed_tests
         file.puts '' unless index == 0
+        file.puts "# redirect: #{element[:redirection]}"
         file.puts "- #{element[:element][:rfml_id]}"
       else
         element[:element][:elements].each do |sub_element|

--- a/spec/exporter_spec.rb
+++ b/spec/exporter_spec.rb
@@ -138,6 +138,7 @@ describe RainforestCli::Exporter do
       end
 
       it 'prints an embedded test rfml id rather than the steps' do
+        expect(file).to include("# redirect:")
         expect(file).to include("- #{embedded_rfml_id}")
         expect(file).to_not include('Embedded Action')
         expect(file).to_not include('Embedded Response')


### PR DESCRIPTION
Fixing issue https://github.com/rainforestapp/rainforest-cli/issues/115

@rainforestapp/customer-product 

I'm not confident with the spec I wrote tho. Please somebody make sure its good enough.