### PR TITLE
Add option to wait for existing run

### DIFF
--- a/.rvmrc
+++ b/.rvmrc
@@ -1,1 +1,0 @@
-rvm use 2.3.0@rainforest-cli --create

--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ Popular command line options are:
 - `--environment-id` - run your tests using this environment. Otherwise it will use your default environment
 - `--conflict OPTION` - use the `abort` option to abort any runs in progress in the same environment as your new run. use the `abort-all` option to abort all runs in progress.
 - `--fg` - results in the foreground - rainforest-cli will not return until the run is complete. This is what you want to make the build pass / fail dependent on rainforest results
+- `--wait RUN_ID` - wait for an existing run to finish instead of starting a new one, and exit with a non-0 code if the run fails. rainforest-cli will exit immediately if the run is already complete.
 - `--fail-fast` - fail the build as soon as the first failed result comes in. If you don't pass this it will wait until 100% of the run is done. Use with `--fg`.
 - `--custom-url` - use a custom url for this run. Example use case: an ad-hoc QA environment with [Fourchette](https://github.com/rainforestapp/fourchette). You will need to specify a `site_id` too for this to work. Note that we will be creating a new environment for this particular run.
 - `--git-trigger` - only trigger a run when the last commit (for a git repo in the current working directory) has contains `@rainforest` and a list of one or more tags. E.g. "Fix checkout process. @rainforest #checkout" would trigger a run for everything tagged `checkout`. This over-rides `--tag` and any tests specified. If no `@rainforest` is detected it will exit 0.

--- a/lib/rainforest/cli/options.rb
+++ b/lib/rainforest/cli/options.rb
@@ -6,7 +6,7 @@ module RainforestCli
     attr_writer :file_name, :tags
     attr_reader :command, :token, :tags, :conflict, :browsers, :site_id, :environment_id,
                 :import_file_name, :import_name, :custom_url, :description, :folder,
-                :debug, :file_name, :test_folder, :embed_tests, :app_source_url, :crowd
+                :debug, :file_name, :test_folder, :embed_tests, :app_source_url, :crowd, :run_id
 
     TOKEN_NOT_REQUIRED = %w{new validate}.freeze
 
@@ -53,6 +53,11 @@ module RainforestCli
 
         opts.on('--fg', 'Run the tests in foreground.') do |value|
           @foreground = value
+        end
+
+        opts.on('--wait ID', Integer, 'Wait for run #ID to complete') do |value|
+          @wait = true
+          @run_id = value
         end
 
         opts.on('--fail-fast', String, "Fail as soon as there is a failure (don't wait for completion)") do |_value|
@@ -140,6 +145,10 @@ module RainforestCli
 
     def failfast?
       @failfast
+    end
+
+    def wait?
+      !!@wait
     end
 
     def foreground?

--- a/lib/rainforest/cli/runner.rb
+++ b/lib/rainforest/cli/runner.rb
@@ -55,9 +55,6 @@ module RainforestCli
             logger.info "Run #{run_id} is now #{response["state"]} and has #{response["result"]}"
             running = false
           end
-        else
-          logger.error "Could not find run #{run_id}."
-          exit 1
         end
         Kernel.sleep 5 if running
       end

--- a/lib/rainforest/cli/runner.rb
+++ b/lib/rainforest/cli/runner.rb
@@ -31,8 +31,10 @@ module RainforestCli
         exit 1
       end
 
+      run_id = response.fetch('id')
+      logger.info "Issued run #{run_id}"
+
       if options.foreground?
-        run_id = response.fetch('id')
         wait_for_run_completion(run_id)
       else
         true

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -102,7 +102,7 @@ describe RainforestCli do
 
         it 'starts the run with the specified tags' do
           expect_any_instance_of(http_client).to receive(:post)
-            .with('/runs', { tags: ['run-me'] }, { retries_on_failures: true }).and_return({})
+            .with('/runs', { tags: ['run-me'] }, { retries_on_failures: true }).and_return({ 'id' => 123 })
 
           start_with_params(params, 0)
         end
@@ -142,7 +142,7 @@ describe RainforestCli do
           '/runs',
           { tests: [], site_id: 3, environment_id: 333 },
           { retries_on_failures: true }
-        ).and_return({})
+        ).and_return({ 'id' => 123 })
         described_class.start(params)
       end
     end
@@ -158,7 +158,7 @@ describe RainforestCli do
           '/runs',
           { tests: [], environment_id: 123 },
           { retries_on_failures: true }
-        ).and_return({})
+        ).and_return({ 'id' => 123 })
         described_class.start(params)
       end
     end
@@ -171,7 +171,7 @@ describe RainforestCli do
           '/runs',
           { smart_folder_id: 123 },
           { retries_on_failures: true }
-        ).and_return({})
+        ).and_return({ 'id' => 123 })
         described_class.start(params)
       end
     end
@@ -184,7 +184,7 @@ describe RainforestCli do
           '/runs',
           { tests: [] },
           { retries_on_failures: true }
-        ).and_return({})
+        ).and_return({ 'id' => 123 })
         allow(ENV).to receive(:[]).with('RAINFOREST_API_TOKEN').and_return('x')
         described_class.start(params)
       end

--- a/spec/options_spec.rb
+++ b/spec/options_spec.rb
@@ -80,6 +80,12 @@ describe RainforestCli::OptionParser do
       its(:foreground?) { is_expected.to eq(true) }
     end
 
+    context 'it parses the --wait flag' do
+      let(:args) { ['run', '--wait', '12345'] }
+      its(:wait?) { is_expected.to be true }
+      its(:run_id) { is_expected.to eq 12345 }
+    end
+
     context 'it parses the api token' do
       let(:args) { ['run', '--token', 'abc', 'all'] }
       its(:token) { should == 'abc'}


### PR DESCRIPTION
Closes #98

@epaulet this would make it easier to run our unit tests in parallel
with RF tests. What do you think?