### PR TITLE
Add junit output for rainforest runs

### DIFF
--- a/lib/rainforest/cli.rb
+++ b/lib/rainforest/cli.rb
@@ -17,6 +17,7 @@ require 'rainforest/cli/exporter'
 require 'rainforest/cli/deleter'
 require 'rainforest/cli/uploader'
 require 'rainforest/cli/resources'
+require 'rainforest/cli/junit_outputter'
 
 module RainforestCli
   def self.start(args)

--- a/lib/rainforest/cli/junit_outputter.rb
+++ b/lib/rainforest/cli/junit_outputter.rb
@@ -1,0 +1,74 @@
+require 'builder'
+require 'time'
+require 'json'
+
+# frozen_string_literal: true
+module RainforestCli
+  class JunitOutputter
+    attr_reader :builder, :client
+
+    def initialize(token, run, tests)
+      @client = HttpClient.new token: token
+      @json_run = run # JSON containing the results of /1/runs/{run_id}.json
+      @json_tests = tests # JSON containing the results of /1/runs/{run_id}/tests.json
+      @builder = Builder::XmlMarkup.new( :indent => 2)
+    end # end initialize
+
+    def dump_summary
+      puts @builder.target!
+    end # end dump_summary
+
+    def build_test_suite
+      @json_tests.each do | test |
+        build_test test
+      end # end do
+    end # end process_run_results
+
+    def build_test(test)
+      test_name = test['title']
+      execution_time = Time.parse(test['updated_at']) - Time.parse(test['created_at'])
+      test_status = test['result']
+      @builder.testcase(:name => test_name, :time => execution_time) do
+        case test_status
+        when "failed"
+          build_failed_test test
+        end # end case
+      end # end do
+    end # end build_test
+
+    def build_failed_test(test)
+      response = client.get("/runs/#{@json_run['id']}/tests/#{test['id']}.json")
+      # Get the number of testers, their distribution of opinions, and a representitive note for failure
+      response['steps'].each do | step |
+        step['browsers'].each do | browser |
+          browser_name = browser['name']
+          reasons = []
+          browser['feedback'].each do | opinion |
+            if opinion['answer_given'] == 'no' and opinion['job_state'] == 'approved'
+              reasons << opinion['note']
+            end
+          end
+          @builder.failure(:browser => browser_name, :reasons => reasons.join(', '))
+        end
+      end
+    end # end build_failed_test
+
+    def parse
+      @builder.instruct! :xml, :version => "1.0", :encoding => "UTF-8"
+      @builder.testsuite(
+        :name => @json_run['description'],
+        :errors => @json_run['total_no_result_tests'],
+        :failures => @json_run['total_failed_tests'],
+        :tests => @json_run['total_tests'],
+        :time => @json_run['time_taken'],
+        :timestamp => @json_run['created_at']) do
+          build_test_suite
+        end
+    end # end parse
+
+    def output(stream)
+      stream.write(@builder.target!)
+    end #end output
+
+  end # end class
+end # end module

--- a/lib/rainforest/cli/options.rb
+++ b/lib/rainforest/cli/options.rb
@@ -15,6 +15,7 @@ module RainforestCli
       @tags = []
       @browsers = nil
       @debug = false
+      @junit = nil
       @token = ENV['RAINFOREST_API_TOKEN']
 
       # NOTE: Disabling line length cop to allow for consistency of syntax
@@ -103,6 +104,10 @@ module RainforestCli
           @app_source_url = value
         end
 
+        opts.on('--junit FILE', 'Gather the results of a run and create junit output in FILE.xml, must be run with --fg') do |value|
+          @junit = value
+        end
+
         opts.on_tail('--help', 'Display help message and exit') do |_value|
           puts opts
           exit 0
@@ -146,6 +151,10 @@ module RainforestCli
       @foreground
     end
 
+    def junit?
+      @junit
+    end
+
     def validate!
       if !TOKEN_NOT_REQUIRED.include?(command)
         unless token
@@ -167,6 +176,12 @@ module RainforestCli
 
       if command == 'rm' && file_name.nil?
         raise ValidationError, 'You must include a file name'
+      end
+
+      if junit?
+        unless foreground?
+          raise ValidationError, 'You can only generate junit test output in foreground mode'
+        end
       end
 
       true

--- a/lib/rainforest/cli/runner.rb
+++ b/lib/rainforest/cli/runner.rb
@@ -29,6 +29,9 @@ module RainforestCli
       if options.foreground?
         run_id = response.fetch('id')
         wait_for_run_completion(run_id)
+        if options.junit?
+          generate_junit_output(run_id, options.junit)
+        end
       else
         true
       end
@@ -59,6 +62,28 @@ module RainforestCli
       if response['result'] != 'passed'
         exit 1
       end
+    end
+
+    def generate_junit_output(run_id, output_filename)
+      run = client.get("/runs/#{run_id}.json")
+
+      if run['error']
+        logger.fatal "Error retrieving results for your run: #{run['error']}"
+        exit 1
+      end
+
+      if run.has_key?('total_tests') and run['total_tests'] != 0
+        tests = client.get("/runs/#{run_id}/tests.json?page_size=#{run['total_tests']}")
+
+        if tests['error']
+          logger.fatal "Error retrieving test details for your run: #{tests['error']}"
+          exit 1
+        end
+
+        outputter = JunitOutputter.new(options.token, run, tests).parse
+      end
+
+      File.open(options.output_filename, 'w') { |file| outputter.output(file) }
     end
 
     def make_create_run_options

--- a/spec/fixtures/failed_test_response.json
+++ b/spec/fixtures/failed_test_response.json
@@ -1,0 +1,29 @@
+{
+  "steps": [
+    {
+      "browsers": [
+        {
+          "name": "this_is_a_browser",
+          "result": "failed",
+          "feedback": [
+            {
+              "job_state": "approved",
+              "answer_given": "no",
+              "note": "This feedback should appear"
+            },
+            {
+              "job_state": "approved",
+              "answer_given": "no",
+              "note": "This \"feedback\" has escaped\n characters"
+            },
+            {
+              "job_state": "unapproved",
+              "answer_given": "no",
+              "note": "This feedback shouldn't \"appear"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/spec/fixtures/runs_response.json
+++ b/spec/fixtures/runs_response.json
@@ -1,0 +1,275 @@
+{
+  "id": 12345,
+  "created_at": "2016-06-21T09:39:50Z",
+  "crowd": "default",
+  "reroute_geo": "default",
+  "environment": {
+    "id": 123,
+    "created_at": "2016-05-05T17:47:55Z",
+    "name": "Enviornment",
+    "default": true,
+    "webhook": null,
+    "webhook_enabled": null,
+    "site_environments": [
+      {
+        "id": 123,
+        "created_at": "2016-05-05T17:47:55Z",
+        "site_id": 123,
+        "environment_id": 123,
+        "url": "http://nowhere.com"
+      }
+    ]
+  },
+  "tests": [
+    {
+      "id": 1,
+      "created_at": "2016-06-21T09:40:07Z",
+      "title": "A passing test case",
+      "test_id": 1,
+      "result": "passed"
+    },
+    {
+      "id": 2,
+      "created_at": "2016-06-21T09:40:07Z",
+      "title": "Another passing test case",
+      "test_id": 37273,
+      "result": "passed"
+    },
+    {
+      "id": 3,
+      "created_at": "2016-06-21T09:40:07Z",
+      "title": "A failing test case",
+      "test_id": 3,
+      "result": "failed"
+    },
+    {
+      "id": 4,
+      "created_at": "2016-06-21T09:40:07Z",
+      "title": "This title \"has\" escaped quotes",
+      "test_id": 4,
+      "result": "failed"
+    }
+  ],
+  "state": "complete",
+  "state_details": {
+    "name": "complete",
+    "is_final_state": true
+  },
+  "result": "failed",
+  "current_progress": {
+    "percent": 100,
+    "total": 4,
+    "complete": 4,
+    "eta": {
+      "seconds": 0,
+      "ts": "2016-07-07T20:13:10.064+00:00"
+    },
+    "no_result": 0,
+    "passed": 2,
+    "failed": 2
+  },
+  "timestamps": {
+    "complete": "2016-06-21T11:43:24.713Z",
+    "in_progress": "2016-06-21T09:40:49.698Z",
+    "provisionally_complete": "2016-06-21T11:39:13.612Z",
+    "validating": "2016-06-21T09:40:13.786Z",
+    "created_at": "2016-06-21T09:39:50.880Z"
+  },
+  "stats": {
+    "total_time_for_one_person": 90423,
+    "total_time_for_rainforest": 7413.775966,
+    "total_rainforest_overhead": 58.812942,
+    "speed_up": 12.2
+  },
+  "browsers": [
+    {
+      "name": "android_phone_landscape",
+      "state": "disabled",
+      "description": "Android Phone Landscape",
+      "category": "phone"
+    },
+    {
+      "name": "android_phone_portrait",
+      "state": "disabled",
+      "description": "Android Phone Portrait",
+      "category": "phone"
+    },
+    {
+      "name": "android_tablet_landscape",
+      "state": "disabled",
+      "description": "Android Tablet Landscape",
+      "category": "tablet"
+    },
+    {
+      "name": "android_tablet_portrait",
+      "state": "disabled",
+      "description": "Android Tablet Portrait",
+      "category": "tablet"
+    },
+    {
+      "name": "chrome",
+      "state": "disabled",
+      "description": "Google Chrome",
+      "category": "browser"
+    },
+    {
+      "name": "chrome_1440_900",
+      "state": "disabled",
+      "description": "Chrome (1440x900)",
+      "category": "browser"
+    },
+    {
+      "name": "firefox",
+      "state": "disabled",
+      "description": "Mozilla Firefox",
+      "category": "browser"
+    },
+    {
+      "name": "firefox_1440_900",
+      "state": "disabled",
+      "description": "Mozilla Firefox (1440x900)",
+      "category": "browser"
+    },
+    {
+      "name": "ie8",
+      "state": "disabled",
+      "description": "Microsoft Internet Explorer 8",
+      "category": "browser"
+    },
+    {
+      "name": "ie9",
+      "state": "disabled",
+      "description": "Microsoft Internet Explorer 9",
+      "category": "browser"
+    },
+    {
+      "name": "ie10",
+      "state": "disabled",
+      "description": "Microsoft Internet Explorer 10",
+      "category": "browser"
+    },
+    {
+      "name": "ie11",
+      "state": "disabled",
+      "description": "Microsoft Internet Explorer 11",
+      "category": "browser"
+    },
+    {
+      "name": "ie10_1440_900",
+      "state": "disabled",
+      "description": "Microsoft Internet Explorer 10 (1440x900)",
+      "category": "browser"
+    },
+    {
+      "name": "ie11_1440_900",
+      "state": "disabled",
+      "description": "Microsoft Internet Explorer 11 (1440x900)",
+      "category": "browser"
+    },
+    {
+      "name": "ie8_1440_900",
+      "state": "disabled",
+      "description": "Microsoft Internet Explorer 8 (1440x900)",
+      "category": "browser"
+    },
+    {
+      "name": "ie9_1440_900",
+      "state": "disabled",
+      "description": "Microsoft Internet Explorer 9 (1440x900)",
+      "category": "browser"
+    },
+    {
+      "name": "office2010",
+      "state": "disabled",
+      "description": "Microsoft Office 2010 Pro",
+      "category": "software"
+    },
+    {
+      "name": "office2013",
+      "state": "disabled",
+      "description": "Microsoft Office 2013 Pro",
+      "category": "software"
+    },
+    {
+      "name": "osx_chrome",
+      "state": "disabled",
+      "description": "Google Chrome (OSX)",
+      "category": "browser"
+    },
+    {
+      "name": "osx_chrome_1440_900",
+      "state": "disabled",
+      "description": "Chrome on OSX Mavericks (1440x900)",
+      "category": "browser"
+    },
+    {
+      "name": "osx_firefox",
+      "state": "disabled",
+      "description": "Mozilla Firefox (OSX)",
+      "category": "browser"
+    },
+    {
+      "name": "osx_firefox_1440_900",
+      "state": "enabled",
+      "description": "Firefox on OS X Mavericks (1440x900)",
+      "category": "browser"
+    },
+    {
+      "name": "safari",
+      "state": "disabled",
+      "description": "Apple Safari",
+      "category": "browser"
+    },
+    {
+      "name": "safari_1440_900",
+      "state": "disabled",
+      "description": "Safari 9 on OSX Mavericks (1440x900)",
+      "category": "browser"
+    },
+    {
+      "name": "ubuntu_chrome",
+      "state": "disabled",
+      "description": "Ubuntu Chrome",
+      "category": "browser"
+    },
+    {
+      "name": "ubuntu_firefox",
+      "state": "disabled",
+      "description": "Ubuntu Firefox",
+      "category": "browser"
+    },
+    {
+      "name": "windows10_edge",
+      "state": "disabled",
+      "description": "Edge on Windows 10",
+      "category": "browser"
+    },
+    {
+      "name": "windows10_ie11",
+      "state": "disabled",
+      "description": "IE11 on Windows 10",
+      "category": "browser"
+    }
+  ],
+  "user": {},
+  "error_logs": [],
+  "filters": {
+    "smart_folder_id": 929
+  },
+  "log_url": "https://someurl.com",
+  "description": "Test Description",
+  "real_cost_to_run": 277,
+  "frontend_url": "https://app.rainforestqa.com/runs/12345",
+  "total_tests": 4,
+  "total_passed_tests": 2,
+  "total_failed_tests": 2,
+  "total_no_result_tests": 0,
+  "sample_test_titles": [
+    "A passing test case",
+    "Another passing test case",
+    "A failing test case",
+    "This title \"has\" escaped quotes"
+  ],
+  "time_taken": 7354.963024,
+  "app_source_url": null
+}

--- a/spec/fixtures/tests_response.json
+++ b/spec/fixtures/tests_response.json
@@ -1,0 +1,130 @@
+[
+  {
+    "id": 1,
+    "created_at": "2016-06-21T09:40:07Z",
+    "test_id": 1,
+    "site_id": 123,
+    "title": "A passing test case",
+    "state": "complete",
+    "result": "passed",
+    "start_uri": "/",
+    "description": "This description \"contains\" escaped\ncharacters",
+    "run_mode": "default",
+    "updated_at": "2016-06-21T10:32:31.987Z",
+    "editable": false,
+    "browsers": [
+      {
+        "id": 1790934,
+        "created_at": "2016-06-21T09:40:47Z",
+        "name": "osx_firefox_1440_900",
+        "description": "Firefox on OS X Mavericks (1440x900)",
+        "category": "browser",
+        "result": "passed",
+        "state": "complete"
+      }
+    ],
+    "step_count": 9,
+    "frontend_url": "https://app.rainforestqa.com/runs/12345/tests/1",
+    "current_progress": {
+      "percent": 100,
+      "total": 1,
+      "complete": 1
+    }
+  },
+  {
+    "id": 2,
+    "created_at": "2016-06-21T09:40:07Z",
+    "test_id": 2,
+    "site_id": 123,
+    "title": "Another passing test case",
+    "state": "complete",
+    "result": "passed",
+    "start_uri": "/",
+    "description": "This description \"contains\" escaped\ncharacters",
+    "run_mode": "default",
+    "updated_at": "2016-06-21T10:12:53.143Z",
+    "editable": false,
+    "browsers": [
+      {
+        "id": 1790912,
+        "created_at": "2016-06-21T09:40:36Z",
+        "name": "osx_firefox_1440_900",
+        "description": "Firefox on OS X Mavericks (1440x900)",
+        "category": "browser",
+        "result": "passed",
+        "state": "complete"
+      }
+    ],
+    "step_count": 10,
+    "frontend_url": "https://app.rainforestqa.com/runs/12345/tests/2",
+    "current_progress": {
+      "percent": 100,
+      "total": 1,
+      "complete": 1
+    }
+  },
+  {
+    "id": 3,
+    "created_at": "2016-06-21T09:40:07Z",
+    "test_id": 3,
+    "site_id": 123,
+    "title": "A failing test case",
+    "state": "complete",
+    "result": "failed",
+    "start_uri": "/",
+    "description": "This description \"contains\" escaped\ncharacters",
+    "run_mode": "default",
+    "updated_at": "2016-06-21T10:30:51.848Z",
+    "editable": false,
+    "browsers": [
+      {
+        "id": 1790911,
+        "created_at": "2016-06-21T09:40:35Z",
+        "name": "osx_firefox_1440_900",
+        "description": "Firefox on OS X Mavericks (1440x900)",
+        "category": "browser",
+        "result": "failed",
+        "state": "complete"
+      }
+    ],
+    "step_count": 10,
+    "frontend_url": "https://app.rainforestqa.com/runs/12345/tests/3",
+    "current_progress": {
+      "percent": 100,
+      "total": 1,
+      "complete": 1
+    }
+  },
+  {
+    "id": 4,
+    "created_at": "2016-06-21T09:40:07Z",
+    "test_id": 4,
+    "site_id": 123,
+    "title": "This title \"has\" escaped quotes",
+    "state": "complete",
+    "result": "failed",
+    "start_uri": "/",
+    "description": "This description \"contains\" escaped\ncharacters",
+    "run_mode": "default",
+    "updated_at": "2016-06-21T10:54:51.771Z",
+    "editable": false,
+    "browsers": [
+      {
+        "id": 1790916,
+        "created_at": "2016-06-21T09:40:40Z",
+        "name": "osx_firefox_1440_900",
+        "description": "Firefox on OS X Mavericks (1440x900)",
+        "category": "browser",
+        "result": "failed",
+        "state": "complete"
+      }
+    ],
+    "step_count": 9,
+    "frontend_url": "https://app.rainforestqa.com/runs/12345/tests/4",
+    "current_progress": {
+      "percent": 100,
+      "total": 1,
+      "complete": 1
+    }
+  }
+]

--- a/spec/junit_outputter_spec.rb
+++ b/spec/junit_outputter_spec.rb
@@ -1,0 +1,32 @@
+require 'json'
+require 'stringio'
+#frozen_string_literal: true
+describe RainforestCli::JunitOutputter do
+  let(:runs_json_results) { JSON.parse(File.read("#{File.dirname(__FILE__)}/fixtures/runs_response.json")) }
+  let(:tests_json_results) { JSON.parse(File.read("#{File.dirname(__FILE__)}/fixtures/tests_response.json")) }
+  let(:failed_test_json) { JSON.parse(File.read("#{File.dirname(__FILE__)}/fixtures/failed_test_response.json")) }
+  let(:test_io) { StringIO.new }
+
+  describe '.build_test_suite' do
+
+    subject { described_class.new('abc123', runs_json_results, tests_json_results) }
+
+    before do
+      allow(subject.client).to receive(:get).and_return(failed_test_json)
+    end
+
+    context 'With a valid response' do
+      it 'Parses the response' do
+        subject.parse
+        subject.output(test_io)
+
+        expect(test_io.string).to include('name="Test Description"')
+        expect(test_io.string).to include('failures="2"')
+        expect(test_io.string).to include("This feedback should appear")
+        expect(test_io.string).not_to include("This feedback shouldn't &quot;appear")
+      end
+    end
+
+  end # end .build_test_suite
+
+end

--- a/spec/options_spec.rb
+++ b/spec/options_spec.rb
@@ -172,5 +172,16 @@ describe RainforestCli::OptionParser do
         it { raises_a_validation_exception }
       end
     end
+
+    context 'with junit output but not in foreground mode' do
+      let(:args) { %w(--token foo --junit some_file.xml) }
+      it { raises_a_validation_exception }
+    end
+
+    context 'with junit output and in foreground mode' do
+      let(:args) { %w(--token foo --junit some_file.xml --fg) }
+      it { does_not_raise_a_validation_exception }
+    end
+
   end
 end

--- a/spec/runner_spec.rb
+++ b/spec/runner_spec.rb
@@ -125,4 +125,41 @@ describe RainforestCli::Runner do
     end
   end
 
+  describe '#generate_junit_ouptut' do
+    context 'on /runs/{run_id}.json API error' do
+      before do
+        allow(subject.client).to receive(:get).with('/runs/some=id.json').and_return({'error'=>'Some API error'})
+      end
+
+      it 'errors out and exits' do
+        expect_any_instance_of(Logger).to receive(:fatal).with('Error retrieving results for your run: Some API error')
+        expect do
+          subject.generate_junit_output('some=id', 'some=filename')
+        end.to raise_error(SystemExit) { |error|
+          expect(error.status).to eq 1
+        }
+      end
+
+    end
+
+    context 'on /runs/{run_id}/tests.json API error' do
+      before do
+        allow(subject.client).to receive(:get).and_return('fake get')
+        allow(subject.client).to receive(:get).with('/runs/some=id.json').and_return({'total_tests'=>'1'})
+        allow(subject.client).to receive(:get).with('/runs/some=id/tests.json?page_size=1').and_return({'error'=>'Some API error'})
+      end
+
+      it 'errors and exits' do
+        expect_any_instance_of(Logger).to receive(:fatal).with('Error retrieving test details for your run: Some API error')
+        expect do
+          subject.generate_junit_output('some=id', 'some=filename')
+        end.to raise_error(SystemExit) { |error|
+          expect(error.status).to eq 1
+        }
+      end
+
+    end
+
+  end
+
 end


### PR DESCRIPTION
Must be used in foreground mode.  Uses the run id and client token to
query the rainforest api after a rainforest run has completed to build
up pass/fail information about the run.  For failed test cases uses the
"notes" given by approved testers who voted no to provide failure
reasons.