### PR TITLE
Junit output

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ Popular command line options are:
 - `--embed-tests` - Use with `rainforest export` to export your tests without extracting the
 steps of an embedded test.
 - `--test-folder /path/to/directory` - Use with `rainforest [new, upload, export]`. If this option is not provided, rainforest-cli will, in the case of 'new' create a directory, or in the case of 'upload' and 'export' use the directory, at the default path `./spec/rainforest/`.
-- `--junit` - Create a junit xml report file with the specified name.  Must be run in foreground mode, or with the report command. Uses the rainforest
+- `--junit-file` - Create a junit xml report file with the specified name.  Must be run in foreground mode, or with the report command. Uses the rainforest
 api to construct a junit report.  This is useful to track tests in CI such as Jenkins or Bamboo.
 - `--run-id` - Only used with the report command.  Specify a past rainforest run by ID number to generate a report for.
 

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ rainforest browsers
 
 To generate a junit xml report for a test run which has already completed
 ```bash
-rainforest report --run_id <run_id> --junit rainforest.xml
+rainforest report --run-id <run-id> --junit rainforest.xml
 ```
 
 ## Options
@@ -194,7 +194,7 @@ steps of an embedded test.
 - `--test-folder /path/to/directory` - Use with `rainforest [new, upload, export]`. If this option is not provided, rainforest-cli will, in the case of 'new' create a directory, or in the case of 'upload' and 'export' use the directory, at the default path `./spec/rainforest/`.
 - `--junit` - Create a junit xml report file with the specified name.  Must be run in foreground mode, or with the report command. Uses the rainforest
 api to construct a junit report.  This is useful to track tests in CI such as Jenkins or Bamboo.
-- `--run_id` - Only used with the report command.  Specify a past rainforest run by ID number to generate a report for.
+- `--run-id` - Only used with the report command.  Specify a past rainforest run by ID number to generate a report for.
 
 
 #### Specifying Test IDs

--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ Run all tests with tag 'run-me' and abort previous in-progress runs.
 rainforest run --tag run-me --fg --conflict abort
 ```
 
+Run all in the foreground and generate a junit xml report.
+
+```bash
+rainforest run all --fg --junit rainforest.xml
+```
+
 ###### Creating and Managing Tests
 
 Create new Rainforest test in RFML format (Rainforest Markup Language).
@@ -102,6 +108,11 @@ rainforest folders
 See a list of all of your browsers and their IDs
 ```bash
 rainforest browsers
+```
+
+To generate a junit xml report for a test run which has already completed
+```bash
+rainforest report --run_id <run_id> --junit rainforest.xml
 ```
 
 ## Options
@@ -181,6 +192,9 @@ Popular command line options are:
 - `--embed-tests` - Use with `rainforest export` to export your tests without extracting the
 steps of an embedded test.
 - `--test-folder /path/to/directory` - Use with `rainforest [new, upload, export]`. If this option is not provided, rainforest-cli will, in the case of 'new' create a directory, or in the case of 'upload' and 'export' use the directory, at the default path `./spec/rainforest/`.
+- `--junit` - Create a junit xml report file with the specified name.  Must be run in foreground mode, or with the report command. Uses the rainforest
+api to construct a junit report.  This is useful to track tests in CI such as Jenkins or Bamboo.
+- `--run_id` - Only used with the report command.  Specify a past rainforest run by ID number to generate a report for.
 
 
 #### Specifying Test IDs

--- a/lib/rainforest/cli.rb
+++ b/lib/rainforest/cli.rb
@@ -17,6 +17,8 @@ require 'rainforest/cli/exporter'
 require 'rainforest/cli/deleter'
 require 'rainforest/cli/uploader'
 require 'rainforest/cli/resources'
+require 'rainforest/cli/junit_outputter'
+require 'rainforest/cli/reporter'
 
 module RainforestCli
   def self.start(args)
@@ -37,6 +39,7 @@ module RainforestCli
     when 'upload' then Uploader.new(options).upload
     when 'rm' then Deleter.new(options).delete
     when 'export' then Exporter.new(options).export
+    when 'report' then Reporter.new(options).report
     when 'sites', 'folders', 'browsers'
       Resources.new(options).public_send(options.command)
     else

--- a/lib/rainforest/cli/http_client.rb
+++ b/lib/rainforest/cli/http_client.rb
@@ -46,6 +46,7 @@ module RainforestCli
         if response.code == 200
           return JSON.parse(response.body)
         else
+          RainforestCli.logger.warn("Status Code: #{response.code}, #{response.body}")
           return nil
         end
       end

--- a/lib/rainforest/cli/junit_outputter.rb
+++ b/lib/rainforest/cli/junit_outputter.rb
@@ -1,0 +1,74 @@
+require 'builder'
+require 'time'
+require 'json'
+
+# frozen_string_literal: true
+module RainforestCli
+  class JunitOutputter
+    attr_reader :builder, :client
+
+    def initialize(token, run, tests)
+      @client = HttpClient.new token: token
+      @json_run = run # JSON containing the results of /1/runs/{run_id}.json
+      @json_tests = tests # JSON containing the results of /1/runs/{run_id}/tests.json
+      @builder = Builder::XmlMarkup.new( :indent => 2)
+    end # end initialize
+
+    def dump_summary
+      puts @builder.target!
+    end # end dump_summary
+
+    def build_test_suite
+      @json_tests.each do | test |
+        build_test test
+      end # end do
+    end # end process_run_results
+
+    def build_test(test)
+      test_name = test['title']
+      execution_time = Time.parse(test['updated_at']) - Time.parse(test['created_at'])
+      test_status = test['result']
+      @builder.testcase(:name => test_name, :time => execution_time) do
+        case test_status
+        when "failed"
+          build_failed_test test
+        end # end case
+      end # end do
+    end # end build_test
+
+    def build_failed_test(test)
+      response = client.get("/runs/#{@json_run['id']}/tests/#{test['id']}.json")
+      # Get the number of testers, their distribution of opinions, and a representitive note for failure
+      response['steps'].each do | step |
+        step['browsers'].each do | browser |
+          browser_name = browser['name']
+          browser['feedback'].each do | opinion |
+            if opinion['answer_given'] == 'no' and opinion['job_state'] == 'approved'
+              if opinion['note'] != ""
+                @builder.failure(:type => browser_name, :message => opinion['note'])
+              end
+            end
+          end
+        end
+      end
+    end # end build_failed_test
+
+    def parse
+      @builder.instruct! :xml, :version => "1.0", :encoding => "UTF-8"
+      @builder.testsuite(
+        :name => @json_run['description'],
+        :errors => @json_run['total_no_result_tests'],
+        :failures => @json_run['total_failed_tests'],
+        :tests => @json_run['total_tests'],
+        :time => Time.parse(@json_run['timestamps']['complete']) - Time.parse(@json_run['timestamps']['created_at']),
+        :timestamp => @json_run['created_at']) do
+          build_test_suite
+        end
+    end # end parse
+
+    def output(stream)
+      stream.write(@builder.target!)
+    end #end output
+
+  end # end class
+end # end module

--- a/lib/rainforest/cli/junit_outputter.rb
+++ b/lib/rainforest/cli/junit_outputter.rb
@@ -14,10 +14,6 @@ module RainforestCli
       @builder = Builder::XmlMarkup.new( :indent => 2)
     end # end initialize
 
-    def dump_summary
-      puts @builder.target!
-    end # end dump_summary
-
     def build_test_suite
       @json_tests.each do | test |
         build_test test

--- a/lib/rainforest/cli/junit_outputter.rb
+++ b/lib/rainforest/cli/junit_outputter.rb
@@ -38,7 +38,6 @@ module RainforestCli
 
     def build_failed_test(test)
       response = client.get("/runs/#{@json_run['id']}/tests/#{test['id']}.json")
-      # Get the number of testers, their distribution of opinions, and a representitive note for failure
       response['steps'].each do | step |
         step['browsers'].each do | browser |
           browser_name = browser['name']

--- a/lib/rainforest/cli/options.rb
+++ b/lib/rainforest/cli/options.rb
@@ -7,7 +7,7 @@ module RainforestCli
     attr_reader :command, :token, :tags, :conflict, :browsers, :site_id, :environment_id,
                 :import_file_name, :import_name, :custom_url, :description, :folder,
                 :debug, :file_name, :test_folder, :embed_tests, :app_source_url, :crowd, :run_id,
-                :junit
+                :junit_file
 
     TOKEN_NOT_REQUIRED = %w{new validate}.freeze
 
@@ -16,7 +16,7 @@ module RainforestCli
       @tags = []
       @browsers = nil
       @debug = false
-      @junit = nil
+      @junit_file = nil
       @run_id = nil
       @token = ENV['RAINFOREST_API_TOKEN']
 
@@ -111,11 +111,11 @@ module RainforestCli
           @app_source_url = value
         end
 
-        opts.on('--junit FILE', 'Gather the results of a run and create junit output in FILE.xml, must be run with --fg') do |value|
-          @junit = value
+        opts.on('--junit-file FILE', 'Gather the results of a run and create junit output in FILE.xml, must be run with --fg') do |value|
+          @junit_file = value
         end
 
-        opts.on('--run_id ID', 'Gather the results of a completed run, must be run with export and --junit') do |value|
+        opts.on('--run-id ID', 'Gather the results of a completed run, must be run with export and --junit') do |value|
           @run_id = value
         end
 
@@ -166,8 +166,8 @@ module RainforestCli
       @foreground
     end
 
-    def junit?
-      @junit
+    def junit_file?
+      @junit_file
     end
 
     def validate!
@@ -193,18 +193,18 @@ module RainforestCli
         raise ValidationError, 'You must include a file name'
       end
 
-      if command == 'run' && junit?
+      if command == 'run' && junit_file?
         unless foreground?
           raise ValidationError, 'You can only generate junit test output in foreground mode'
         end
       end
 
       if command == 'report'
-        if junit.nil?
+        if junit_file.nil?
           raise ValidationError, 'You must specify a junit ouptut filename'
         end
         if run_id.nil?
-          raise ValidationError, 'You must specify a run_id to generate a report for'
+          raise ValidationError, 'You must specify a run-id to generate a report for'
         end
       end
 

--- a/lib/rainforest/cli/options.rb
+++ b/lib/rainforest/cli/options.rb
@@ -6,7 +6,8 @@ module RainforestCli
     attr_writer :file_name, :tags
     attr_reader :command, :token, :tags, :conflict, :browsers, :site_id, :environment_id,
                 :import_file_name, :import_name, :custom_url, :description, :folder,
-                :debug, :file_name, :test_folder, :embed_tests, :app_source_url, :crowd, :run_id
+                :debug, :file_name, :test_folder, :embed_tests, :app_source_url, :crowd, :run_id,
+                :junit
 
     TOKEN_NOT_REQUIRED = %w{new validate}.freeze
 
@@ -15,6 +16,8 @@ module RainforestCli
       @tags = []
       @browsers = nil
       @debug = false
+      @junit = nil
+      @run_id = nil
       @token = ENV['RAINFOREST_API_TOKEN']
 
       # NOTE: Disabling line length cop to allow for consistency of syntax
@@ -108,6 +111,14 @@ module RainforestCli
           @app_source_url = value
         end
 
+        opts.on('--junit FILE', 'Gather the results of a run and create junit output in FILE.xml, must be run with --fg') do |value|
+          @junit = value
+        end
+
+        opts.on('--run_id ID', 'Gather the results of a completed run, must be run with export and --junit') do |value|
+          @run_id = value
+        end
+
         opts.on_tail('--help', 'Display help message and exit') do |_value|
           puts opts
           exit 0
@@ -155,6 +166,10 @@ module RainforestCli
       @foreground
     end
 
+    def junit?
+      @junit
+    end
+
     def validate!
       if !TOKEN_NOT_REQUIRED.include?(command)
         unless token
@@ -176,6 +191,21 @@ module RainforestCli
 
       if command == 'rm' && file_name.nil?
         raise ValidationError, 'You must include a file name'
+      end
+
+      if command == 'run' && junit?
+        unless foreground?
+          raise ValidationError, 'You can only generate junit test output in foreground mode'
+        end
+      end
+
+      if command == 'report'
+        if junit.nil?
+          raise ValidationError, 'You must specify a junit ouptut filename'
+        end
+        if run_id.nil?
+          raise ValidationError, 'You must specify a run_id to generate a report for'
+        end
       end
 
       true

--- a/lib/rainforest/cli/reporter.rb
+++ b/lib/rainforest/cli/reporter.rb
@@ -1,3 +1,5 @@
+require 'fileutils'
+
 #frozen_string_literal: true
 module RainforestCli
   class Reporter
@@ -8,7 +10,7 @@ module RainforestCli
       @options = options
       @client = HttpClient.new token: options.token
       @run_id = options.run_id
-      @output_filename = options.junit
+      @output_filename = options.junit_file
     end
 
     def report
@@ -45,6 +47,10 @@ module RainforestCli
 
         outputter = JunitOutputter.new(@options.token, run, tests)
         outputter.parse
+      end
+
+      unless File.directory?(File.dirname(@output_filename))
+        FileUtils.mkdir_p(File.dirname(@output_filename))
       end
 
       File.open(@output_filename, 'w') { |file| outputter.output(file) }

--- a/lib/rainforest/cli/reporter.rb
+++ b/lib/rainforest/cli/reporter.rb
@@ -1,0 +1,58 @@
+#frozen_string_literal: true
+module RainforestCli
+  class Reporter
+    attr_reader :client
+    attr_writer :run_id
+
+    def initialize(options)
+      @options = options
+      @client = HttpClient.new token: options.token
+      @run_id = options.run_id
+      @output_filename = options.junit
+    end
+
+    def report
+      if @run_id == nil
+        logger.fatal "Reporter needs a valid run_id to report on"
+      else
+        logger.info "Generating JUNIT report for #{@run_id} : #{@output_filename}"
+      end
+
+      run = client.get("/runs/#{@run_id}.json")
+
+      if run == nil
+        logger.fatal "Non 200 code recieved"
+        exit 1
+      end
+
+      if run['error']
+        logger.fatal "Error retrieving results for your run: #{run['error']}"
+        exit 1
+      end
+
+      if run.has_key?('total_tests') and run['total_tests'] != 0
+        tests = client.get("/runs/#{@run_id}/tests.json?page_size=#{run['total_tests']}")
+
+        if tests == nil
+          logger.fatal "Non 200 code recieved"
+          exit 1
+        end
+
+        if tests.kind_of?(Hash) and tests['error'] # if this had worked tests would be an array
+          logger.fatal "Error retrieving test details for your run: #{tests['error']}"
+          exit 1
+        end
+
+        outputter = JunitOutputter.new(@options.token, run, tests)
+        outputter.parse
+      end
+
+      File.open(@output_filename, 'w') { |file| outputter.output(file) }
+    end
+
+    def logger
+      RainforestCli.logger
+    end
+
+  end
+end

--- a/lib/rainforest/cli/runner.rb
+++ b/lib/rainforest/cli/runner.rb
@@ -36,7 +36,7 @@ module RainforestCli
 
       if options.foreground?
         response = wait_for_run_completion(run_id)
-        if options.junit?
+        if options.junit_file?
           reporter = Reporter.new(options)
           reporter.run_id = run_id
           reporter.report

--- a/lib/rainforest/cli/runner.rb
+++ b/lib/rainforest/cli/runner.rb
@@ -35,7 +35,16 @@ module RainforestCli
       logger.info "Issued run #{run_id}"
 
       if options.foreground?
-        wait_for_run_completion(run_id)
+        response = wait_for_run_completion(run_id)
+        if options.junit?
+          reporter = Reporter.new(options)
+          reporter.run_id = run_id
+          reporter.report
+        end
+
+        if response['result'] != 'passed'
+          exit 1
+        end
       else
         true
       end
@@ -63,9 +72,7 @@ module RainforestCli
         logger.info "The detailed results are available at #{response['frontend_url']}"
       end
 
-      if response['result'] != 'passed'
-        exit 1
-      end
+      return response
     end
 
     def make_create_run_options

--- a/rainforest-cli.gemspec
+++ b/rainforest-cli.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'ruby-progressbar', '~> 1.7', '>= 1.7.5'
   spec.add_dependency 'rainforest', '~> 2.1', '>= 2.1.0'
   spec.add_dependency 'http-exceptions', '~> 0.0', '>= 0.0.4'
+  spec.add_dependency 'builder', '~> 3.2'
   spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency 'rake', '~> 10.4', '>= 10.4.2'
 end

--- a/spec/fixtures/failed_test_response.json
+++ b/spec/fixtures/failed_test_response.json
@@ -1,0 +1,29 @@
+{
+  "steps": [
+    {
+      "browsers": [
+        {
+          "name": "this_is_a_browser",
+          "result": "failed",
+          "feedback": [
+            {
+              "job_state": "approved",
+              "answer_given": "no",
+              "note": "This feedback should appear"
+            },
+            {
+              "job_state": "approved",
+              "answer_given": "no",
+              "note": "This \"feedback\" has escaped\n characters"
+            },
+            {
+              "job_state": "unapproved",
+              "answer_given": "no",
+              "note": "This feedback shouldn't \"appear"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/spec/fixtures/runs_response.json
+++ b/spec/fixtures/runs_response.json
@@ -1,0 +1,275 @@
+{
+  "id": 12345,
+  "created_at": "2016-06-21T09:39:50Z",
+  "crowd": "default",
+  "reroute_geo": "default",
+  "environment": {
+    "id": 123,
+    "created_at": "2016-05-05T17:47:55Z",
+    "name": "Enviornment",
+    "default": true,
+    "webhook": null,
+    "webhook_enabled": null,
+    "site_environments": [
+      {
+        "id": 123,
+        "created_at": "2016-05-05T17:47:55Z",
+        "site_id": 123,
+        "environment_id": 123,
+        "url": "http://nowhere.com"
+      }
+    ]
+  },
+  "tests": [
+    {
+      "id": 1,
+      "created_at": "2016-06-21T09:40:07Z",
+      "title": "A passing test case",
+      "test_id": 1,
+      "result": "passed"
+    },
+    {
+      "id": 2,
+      "created_at": "2016-06-21T09:40:07Z",
+      "title": "Another passing test case",
+      "test_id": 37273,
+      "result": "passed"
+    },
+    {
+      "id": 3,
+      "created_at": "2016-06-21T09:40:07Z",
+      "title": "A failing test case",
+      "test_id": 3,
+      "result": "failed"
+    },
+    {
+      "id": 4,
+      "created_at": "2016-06-21T09:40:07Z",
+      "title": "This title \"has\" escaped quotes",
+      "test_id": 4,
+      "result": "failed"
+    }
+  ],
+  "state": "complete",
+  "state_details": {
+    "name": "complete",
+    "is_final_state": true
+  },
+  "result": "failed",
+  "current_progress": {
+    "percent": 100,
+    "total": 4,
+    "complete": 4,
+    "eta": {
+      "seconds": 0,
+      "ts": "2016-07-07T20:13:10.064+00:00"
+    },
+    "no_result": 0,
+    "passed": 2,
+    "failed": 2
+  },
+  "timestamps": {
+    "complete": "2016-06-21T11:43:24.713Z",
+    "in_progress": "2016-06-21T09:40:49.698Z",
+    "provisionally_complete": "2016-06-21T11:39:13.612Z",
+    "validating": "2016-06-21T09:40:13.786Z",
+    "created_at": "2016-06-21T09:39:50.880Z"
+  },
+  "stats": {
+    "total_time_for_one_person": 90423,
+    "total_time_for_rainforest": 7413.775966,
+    "total_rainforest_overhead": 58.812942,
+    "speed_up": 12.2
+  },
+  "browsers": [
+    {
+      "name": "android_phone_landscape",
+      "state": "disabled",
+      "description": "Android Phone Landscape",
+      "category": "phone"
+    },
+    {
+      "name": "android_phone_portrait",
+      "state": "disabled",
+      "description": "Android Phone Portrait",
+      "category": "phone"
+    },
+    {
+      "name": "android_tablet_landscape",
+      "state": "disabled",
+      "description": "Android Tablet Landscape",
+      "category": "tablet"
+    },
+    {
+      "name": "android_tablet_portrait",
+      "state": "disabled",
+      "description": "Android Tablet Portrait",
+      "category": "tablet"
+    },
+    {
+      "name": "chrome",
+      "state": "disabled",
+      "description": "Google Chrome",
+      "category": "browser"
+    },
+    {
+      "name": "chrome_1440_900",
+      "state": "disabled",
+      "description": "Chrome (1440x900)",
+      "category": "browser"
+    },
+    {
+      "name": "firefox",
+      "state": "disabled",
+      "description": "Mozilla Firefox",
+      "category": "browser"
+    },
+    {
+      "name": "firefox_1440_900",
+      "state": "disabled",
+      "description": "Mozilla Firefox (1440x900)",
+      "category": "browser"
+    },
+    {
+      "name": "ie8",
+      "state": "disabled",
+      "description": "Microsoft Internet Explorer 8",
+      "category": "browser"
+    },
+    {
+      "name": "ie9",
+      "state": "disabled",
+      "description": "Microsoft Internet Explorer 9",
+      "category": "browser"
+    },
+    {
+      "name": "ie10",
+      "state": "disabled",
+      "description": "Microsoft Internet Explorer 10",
+      "category": "browser"
+    },
+    {
+      "name": "ie11",
+      "state": "disabled",
+      "description": "Microsoft Internet Explorer 11",
+      "category": "browser"
+    },
+    {
+      "name": "ie10_1440_900",
+      "state": "disabled",
+      "description": "Microsoft Internet Explorer 10 (1440x900)",
+      "category": "browser"
+    },
+    {
+      "name": "ie11_1440_900",
+      "state": "disabled",
+      "description": "Microsoft Internet Explorer 11 (1440x900)",
+      "category": "browser"
+    },
+    {
+      "name": "ie8_1440_900",
+      "state": "disabled",
+      "description": "Microsoft Internet Explorer 8 (1440x900)",
+      "category": "browser"
+    },
+    {
+      "name": "ie9_1440_900",
+      "state": "disabled",
+      "description": "Microsoft Internet Explorer 9 (1440x900)",
+      "category": "browser"
+    },
+    {
+      "name": "office2010",
+      "state": "disabled",
+      "description": "Microsoft Office 2010 Pro",
+      "category": "software"
+    },
+    {
+      "name": "office2013",
+      "state": "disabled",
+      "description": "Microsoft Office 2013 Pro",
+      "category": "software"
+    },
+    {
+      "name": "osx_chrome",
+      "state": "disabled",
+      "description": "Google Chrome (OSX)",
+      "category": "browser"
+    },
+    {
+      "name": "osx_chrome_1440_900",
+      "state": "disabled",
+      "description": "Chrome on OSX Mavericks (1440x900)",
+      "category": "browser"
+    },
+    {
+      "name": "osx_firefox",
+      "state": "disabled",
+      "description": "Mozilla Firefox (OSX)",
+      "category": "browser"
+    },
+    {
+      "name": "osx_firefox_1440_900",
+      "state": "enabled",
+      "description": "Firefox on OS X Mavericks (1440x900)",
+      "category": "browser"
+    },
+    {
+      "name": "safari",
+      "state": "disabled",
+      "description": "Apple Safari",
+      "category": "browser"
+    },
+    {
+      "name": "safari_1440_900",
+      "state": "disabled",
+      "description": "Safari 9 on OSX Mavericks (1440x900)",
+      "category": "browser"
+    },
+    {
+      "name": "ubuntu_chrome",
+      "state": "disabled",
+      "description": "Ubuntu Chrome",
+      "category": "browser"
+    },
+    {
+      "name": "ubuntu_firefox",
+      "state": "disabled",
+      "description": "Ubuntu Firefox",
+      "category": "browser"
+    },
+    {
+      "name": "windows10_edge",
+      "state": "disabled",
+      "description": "Edge on Windows 10",
+      "category": "browser"
+    },
+    {
+      "name": "windows10_ie11",
+      "state": "disabled",
+      "description": "IE11 on Windows 10",
+      "category": "browser"
+    }
+  ],
+  "user": {},
+  "error_logs": [],
+  "filters": {
+    "smart_folder_id": 929
+  },
+  "log_url": "https://someurl.com",
+  "description": "Test Description",
+  "real_cost_to_run": 277,
+  "frontend_url": "https://app.rainforestqa.com/runs/12345",
+  "total_tests": 4,
+  "total_passed_tests": 2,
+  "total_failed_tests": 2,
+  "total_no_result_tests": 0,
+  "sample_test_titles": [
+    "A passing test case",
+    "Another passing test case",
+    "A failing test case",
+    "This title \"has\" escaped quotes"
+  ],
+  "time_taken": 7354.963024,
+  "app_source_url": null
+}

--- a/spec/fixtures/tests_response.json
+++ b/spec/fixtures/tests_response.json
@@ -1,0 +1,130 @@
+[
+  {
+    "id": 1,
+    "created_at": "2016-06-21T09:40:07Z",
+    "test_id": 1,
+    "site_id": 123,
+    "title": "A passing test case",
+    "state": "complete",
+    "result": "passed",
+    "start_uri": "/",
+    "description": "This description \"contains\" escaped\ncharacters",
+    "run_mode": "default",
+    "updated_at": "2016-06-21T10:32:31.987Z",
+    "editable": false,
+    "browsers": [
+      {
+        "id": 1790934,
+        "created_at": "2016-06-21T09:40:47Z",
+        "name": "osx_firefox_1440_900",
+        "description": "Firefox on OS X Mavericks (1440x900)",
+        "category": "browser",
+        "result": "passed",
+        "state": "complete"
+      }
+    ],
+    "step_count": 9,
+    "frontend_url": "https://app.rainforestqa.com/runs/12345/tests/1",
+    "current_progress": {
+      "percent": 100,
+      "total": 1,
+      "complete": 1
+    }
+  },
+  {
+    "id": 2,
+    "created_at": "2016-06-21T09:40:07Z",
+    "test_id": 2,
+    "site_id": 123,
+    "title": "Another passing test case",
+    "state": "complete",
+    "result": "passed",
+    "start_uri": "/",
+    "description": "This description \"contains\" escaped\ncharacters",
+    "run_mode": "default",
+    "updated_at": "2016-06-21T10:12:53.143Z",
+    "editable": false,
+    "browsers": [
+      {
+        "id": 1790912,
+        "created_at": "2016-06-21T09:40:36Z",
+        "name": "osx_firefox_1440_900",
+        "description": "Firefox on OS X Mavericks (1440x900)",
+        "category": "browser",
+        "result": "passed",
+        "state": "complete"
+      }
+    ],
+    "step_count": 10,
+    "frontend_url": "https://app.rainforestqa.com/runs/12345/tests/2",
+    "current_progress": {
+      "percent": 100,
+      "total": 1,
+      "complete": 1
+    }
+  },
+  {
+    "id": 3,
+    "created_at": "2016-06-21T09:40:07Z",
+    "test_id": 3,
+    "site_id": 123,
+    "title": "A failing test case",
+    "state": "complete",
+    "result": "failed",
+    "start_uri": "/",
+    "description": "This description \"contains\" escaped\ncharacters",
+    "run_mode": "default",
+    "updated_at": "2016-06-21T10:30:51.848Z",
+    "editable": false,
+    "browsers": [
+      {
+        "id": 1790911,
+        "created_at": "2016-06-21T09:40:35Z",
+        "name": "osx_firefox_1440_900",
+        "description": "Firefox on OS X Mavericks (1440x900)",
+        "category": "browser",
+        "result": "failed",
+        "state": "complete"
+      }
+    ],
+    "step_count": 10,
+    "frontend_url": "https://app.rainforestqa.com/runs/12345/tests/3",
+    "current_progress": {
+      "percent": 100,
+      "total": 1,
+      "complete": 1
+    }
+  },
+  {
+    "id": 4,
+    "created_at": "2016-06-21T09:40:07Z",
+    "test_id": 4,
+    "site_id": 123,
+    "title": "This title \"has\" escaped quotes",
+    "state": "complete",
+    "result": "failed",
+    "start_uri": "/",
+    "description": "This description \"contains\" escaped\ncharacters",
+    "run_mode": "default",
+    "updated_at": "2016-06-21T10:54:51.771Z",
+    "editable": false,
+    "browsers": [
+      {
+        "id": 1790916,
+        "created_at": "2016-06-21T09:40:40Z",
+        "name": "osx_firefox_1440_900",
+        "description": "Firefox on OS X Mavericks (1440x900)",
+        "category": "browser",
+        "result": "failed",
+        "state": "complete"
+      }
+    ],
+    "step_count": 9,
+    "frontend_url": "https://app.rainforestqa.com/runs/12345/tests/4",
+    "current_progress": {
+      "percent": 100,
+      "total": 1,
+      "complete": 1
+    }
+  }
+]

--- a/spec/http_client_spec.rb
+++ b/spec/http_client_spec.rb
@@ -53,5 +53,28 @@ describe RainforestCli::HttpClient do
         end
       end
     end
+
+    describe 'non 200 codes' do
+      context '404 not found'do
+        let(:url) { 'http://some.url.com' }
+        let(:response) { instance_double('HTTParty::Response', code: 404, body: {'error'=>'some error', 'type'=>'some type'}.to_json) }
+        subject { described_class.new({ token: 'foo' }).get(url, {}) }
+
+        before do
+          allow(HTTParty).to receive(:get).and_raise(SocketError)
+        end
+
+        it 'gets an error 404 and prints the error' do
+          expect(HTTParty).to receive(:get).and_return(response)
+          expect_any_instance_of(Logger).to receive(:warn).with('Status Code: 404, {"error":"some error","type":"some type"}')
+          expect(subject)
+        end
+
+        it 'returns nil' do
+          expect(HTTParty).to receive(:get).and_return(response)
+          expect(subject).to eq(nil)
+        end
+      end
+    end
   end
 end

--- a/spec/junit_outputter_spec.rb
+++ b/spec/junit_outputter_spec.rb
@@ -1,0 +1,32 @@
+require 'json'
+require 'stringio'
+#frozen_string_literal: true
+describe RainforestCli::JunitOutputter do
+  let(:runs_json_results) { JSON.parse(File.read("#{File.dirname(__FILE__)}/fixtures/runs_response.json")) }
+  let(:tests_json_results) { JSON.parse(File.read("#{File.dirname(__FILE__)}/fixtures/tests_response.json")) }
+  let(:failed_test_json) { JSON.parse(File.read("#{File.dirname(__FILE__)}/fixtures/failed_test_response.json")) }
+  let(:test_io) { StringIO.new }
+
+  describe '.build_test_suite' do
+
+    subject { described_class.new('abc123', runs_json_results, tests_json_results) }
+
+    before do
+      allow(subject.client).to receive(:get).and_return(failed_test_json)
+    end
+
+    context 'With a valid response' do
+      it 'Parses the response' do
+        subject.parse
+        subject.output(test_io)
+
+        expect(test_io.string).to include('name="Test Description"')
+        expect(test_io.string).to include('failures="2"')
+        expect(test_io.string).to include("This feedback should appear")
+        expect(test_io.string).not_to include("This feedback shouldn't &quot;appear")
+      end
+    end
+
+  end # end .build_test_suite
+
+end

--- a/spec/options_spec.rb
+++ b/spec/options_spec.rb
@@ -180,28 +180,28 @@ describe RainforestCli::OptionParser do
     end
 
     context 'with junit output but not in foreground mode' do
-      let(:args) { %w(run --token foo --junit some_file.xml) }
+      let(:args) { %w(run --token foo --junit-file some_file.xml) }
       it { raises_a_validation_exception }
     end
 
     context 'with junit output and in foreground mode' do
-      let(:args) { %w(--token foo --junit some_file.xml --fg) }
+      let(:args) { %w(--token foo --junit-file some_file.xml --fg) }
       it { does_not_raise_a_validation_exception }
     end
 
     context 'valdiating the report command' do
       context 'with a valid junit and run_id' do
-        let(:args) { ['report', '--junit', 'somefile.xml', '--run_id', '12345', '--token', 'foo'] }
+        let(:args) { ['report', '--junit-file', 'somefile.xml', '--run-id', '12345', '--token', 'foo'] }
         it {does_not_raise_a_validation_exception }
       end
 
       context 'with a junit but no run_id' do
-        let(:args) { ['report', '--junit', 'somefile.xml', '--token', 'foo'] }
+        let(:args) { ['report', '--junit-file', 'somefile.xml', '--token', 'foo'] }
         it { raises_a_validation_exception }
       end
 
       context 'with a run_id but no junit' do
-        let(:args) { ['report', '--run_id', '12345', '--token', 'foo'] }
+        let(:args) { ['report', '--run-id', '12345', '--token', 'foo'] }
       end
     end
 

--- a/spec/options_spec.rb
+++ b/spec/options_spec.rb
@@ -178,5 +178,32 @@ describe RainforestCli::OptionParser do
         it { raises_a_validation_exception }
       end
     end
+
+    context 'with junit output but not in foreground mode' do
+      let(:args) { %w(run --token foo --junit some_file.xml) }
+      it { raises_a_validation_exception }
+    end
+
+    context 'with junit output and in foreground mode' do
+      let(:args) { %w(--token foo --junit some_file.xml --fg) }
+      it { does_not_raise_a_validation_exception }
+    end
+
+    context 'valdiating the report command' do
+      context 'with a valid junit and run_id' do
+        let(:args) { ['report', '--junit', 'somefile.xml', '--run_id', '12345', '--token', 'foo'] }
+        it {does_not_raise_a_validation_exception }
+      end
+
+      context 'with a junit but no run_id' do
+        let(:args) { ['report', '--junit', 'somefile.xml', '--token', 'foo'] }
+        it { raises_a_validation_exception }
+      end
+
+      context 'with a run_id but no junit' do
+        let(:args) { ['report', '--run_id', '12345', '--token', 'foo'] }
+      end
+    end
+
   end
 end

--- a/spec/reporter_spec.rb
+++ b/spec/reporter_spec.rb
@@ -1,7 +1,7 @@
 
 
 describe RainforestCli::Reporter do
-  let(:args) { %w(report --token abc123 --run_id 12345 --junit somefile.xml) }
+  let(:args) { %w(report --token abc123 --run-id 12345 --junit-file somefile.xml) }
   let(:options) { RainforestCli::OptionParser.new(args) }
 
   subject { described_class.new(options) }

--- a/spec/reporter_spec.rb
+++ b/spec/reporter_spec.rb
@@ -1,0 +1,51 @@
+
+
+describe RainforestCli::Reporter do
+  let(:args) { %w(report --token abc123 --run_id 12345 --junit somefile.xml) }
+  let(:options) { RainforestCli::OptionParser.new(args) }
+
+  subject { described_class.new(options) }
+
+  describe '#report' do
+    context 'on /runs/{run_id}.json API error' do
+      before do
+        allow(subject.client).to receive(:get).with('/runs/12345.json').and_return({'error'=>'Some API error'})
+      end
+
+      it 'errors out and exits' do
+        expect_any_instance_of(Logger).to receive(:fatal).with('Error retrieving results for your run: Some API error')
+        expect do
+          subject.report
+        end.to raise_error(SystemExit) { |error|
+          expect(error.status).to eq 1
+        }
+      end
+
+    end
+
+    context 'on /runs/{run_id}/tests.json API error' do
+      before do
+        allow(subject.client).to receive(:get).with('/runs/12345.json').and_return({'total_tests'=>'1'})
+        allow(subject.client).to receive(:get).with('/runs/12345/tests.json?page_size=1').and_return({'error'=>'Some API error'})
+      end
+
+      it 'errors and exits' do
+        expect_any_instance_of(Logger).to receive(:fatal).with('Error retrieving test details for your run: Some API error')
+        expect do
+          subject.report
+        end.to raise_error(SystemExit) { |error|
+          expect(error.status).to eq 1
+        }
+      end
+
+    end
+
+    context 'with working API calls creates JunitOutputter' do
+      before do
+        allow(subject.client).to receive(:get).with('/runs/12345.json').and_return()
+        allow(subject.client).to receive(:get).with('/runs/12345/tests.json?page_size=1').and_return()
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
Add junit output for rainforest runs
-----------------------------------

Must be used in forground mode.  Uses the run id and client token to
query the rainforest api after a rainforest run has completed to build
up pass/fail information about the run.  For failed test cases uses the
"notes" given by approved testers who voted no to provide failure
reasons.

Generating a useful Junit output from the API takes at least two GETs.  A hit on `run` and a hit on `tests`, the former to get information about the total number of tests, the amount of time it was run etc, while the latter is needed to get slightly more detail for each test case efficiently. The tests endpoint allows the parser to determine the amount of time the test took to complete (typical content of Junit reports).

Where the parser becomes slightly heavier is with failed test cases, where it needs to hit the API to get the specific details of each test failure.  It then uses this information to gather the valid notes on the test failure to act as a "traceback" for the test failure.  Noting the browser and the failure reason.

Here is an example of what this parsed output looks like in a CI tool like Bamboo:
![image](https://cloud.githubusercontent.com/assets/13895507/16845301/404ea8a4-499d-11e6-8893-4863c426872a.png)

![image](https://cloud.githubusercontent.com/assets/13895507/16845331/5c5cf4a6-499d-11e6-94d9-25c92de1a82d.png)

This is largely accomplished by the second class I added `JunitOutputter`.  This class does the heavy lifting of organizing the JSON data returned from the rainforest API into an XML report, using `XmlBuilder` to handle all of the XML.

I added unit tests for all the classes I modified, and added new specs for the classes I added, and tried to follow the coding style of the modules as I was editing them.

A couple of concerns, The return from the `tests` endpoint is paginated. My approach of specifying that the page returned contain as many test cases as the run will only function if there either is no upper limit on the number of tests which can be returned, or if the run being reported on contains fewer test cases than that limit.  This logic may need to be made more complicated.

Another is that this Junit output generates results tracking 1 to 1 with the number of rainforest test cases.  When issuing a rainforest run you can ask that a test case be run against many different browsers and environments. And I do not feel like this information is being properly reflected in the Junit output.

I think what I have here is already a pretty long PR (luckily most of the lines are test fixtures though) and it provides at least the minimum of getting the number of passing and failing test cases from a rainforest run along with the given reason for test failures. Let me know what you think.