### PR TITLE
Fix uploads

### DIFF
--- a/lib/rainforest_cli.rb
+++ b/lib/rainforest_cli.rb
@@ -24,6 +24,7 @@ module RainforestCli
   def self.start(args)
     options = OptionParser.new(args)
     @http_client = HttpClient.new(token: options.token)
+    ::Rainforest.api_key = options.token
     OptionParser.new(['--help']) if args.size == 0
 
     begin


### PR DESCRIPTION
Uploads were broken as part of #178 because the API key is no longer set for the areas that still use the Ruby gem.
