### PR TITLE
Don't try to parameterize values that are already set

### DIFF
--- a/lib/rainforest_cli/test_parser/step.rb
+++ b/lib/rainforest_cli/test_parser/step.rb
@@ -15,10 +15,28 @@ class RainforestCli::TestParser::Step < Struct.new(:action, :response, :redirect
   end
 
   def uploadable_in_action
-    action.scan(UPLOADABLE_REGEX)
+    action.scan(UPLOADABLE_REGEX).select do |match|
+      needs_parameterization?(match)
+    end
   end
 
   def uploadable_in_response
-    response.scan(UPLOADABLE_REGEX)
+    response.scan(UPLOADABLE_REGEX).select do |match|
+      needs_parameterization?(match)
+    end
+  end
+
+  private
+
+  def needs_parameterization?(match)
+    argument = match[1]
+    parameters = argument.split(',').map(&:strip)
+    if parameters.length >= 2
+      has_file_id = parameters[0].to_i > 0
+      has_file_sig = parameters[1].length == 6
+      !(has_file_id && has_file_sig)
+    else
+      true
+    end
   end
 end

--- a/spec/rainforest_cli/test_parser/step_spec.rb
+++ b/spec/rainforest_cli/test_parser/step_spec.rb
@@ -9,6 +9,14 @@ describe RainforestCli::TestParser::Step do
     'Download 1: {{ file.download(./foo) }}. Download 2: {{file.download(bar/baz)   }}'
   end
 
+  let(:parameterized_screenshot_string) do
+    'Picture 1: {{ file.screenshot(./foo) }}. Picture 2: {{file.screenshot(123, signat)   }}'
+  end
+
+  let(:parameterized_download_string) do
+    'Download 1: {{ file.download(./foo) }}. Download 2: {{file.download(123, signat, baz.txt)   }}'
+  end
+
   shared_examples 'a method that detects step variables' do |att|
     it 'correctly detects a screenshot step variable' do
       subject[att] = screenshot_string
@@ -16,10 +24,22 @@ describe RainforestCli::TestParser::Step do
         .to eq([['screenshot', './foo'], ['screenshot', 'bar/baz']])
     end
 
-    it 'correctly detects the download step variable' do
+    it 'correctly detects a download step variable' do
       subject[att] = download_string
       expect(subject.send(:"uploadable_in_#{att}"))
         .to eq([['download', './foo'], ['download', 'bar/baz']])
+    end
+
+    it 'does not detect a parameterized screenshot step variable' do
+      subject[att] = parameterized_screenshot_string
+      expect(subject.send(:"uploadable_in_#{att}"))
+        .to eq([['screenshot', './foo']])
+    end
+
+    it 'does not detect a parameterized download step variable' do
+      subject[att] = parameterized_download_string
+      expect(subject.send(:"uploadable_in_#{att}"))
+        .to eq([['download', './foo']])
     end
   end
 


### PR DESCRIPTION
Currently we don't check if the parameters for `file.download` and `file.screenshot` are already in place. We try to replace them all and give an error.