### PR TITLE
Don't upload test meta data to description anymore

### DIFF
--- a/lib/rainforest_cli/test_parser.rb
+++ b/lib/rainforest_cli/test_parser.rb
@@ -26,8 +26,7 @@ module RainforestCli::TestParser
       @test.browsers = []
     end
 
-    TEST_DATA_FIELDS = [:start_uri, :title, :site_id].freeze
-    STEP_DATA_FIELDS = [:redirect].freeze
+    TEST_DATA_FIELDS = [:start_uri, :title, :site_id, :tags, :browsers].freeze
     CSV_FIELDS = [:tags, :browsers].freeze
 
     def process
@@ -50,8 +49,7 @@ module RainforestCli::TestParser
               @test.errors[line_no] = Error.new(line_no, 'Redirection value must be true or false')
             end
           else
-            special_fields = (CSV_FIELDS + TEST_DATA_FIELDS)
-            matched_field = special_fields.find { |f| comment.start_with?("#{f}:") }
+            matched_field = TEST_DATA_FIELDS.find { |f| comment.start_with?("#{f}:") }
             if matched_field.nil?
               # comment, store in description
               @test.description += comment + "\n"

--- a/spec/rainforest-example/example_test.rfml
+++ b/spec/rainforest-example/example_test.rfml
@@ -3,6 +3,9 @@
 # tags: foo,bar,baz
 # site_id: 456
 # start_uri: /start_uri
+# This is a comment
 
+# this is also a comment
+# redirect: false
 This is a step action.
 This is a question?

--- a/spec/rainforest_cli/test_parser_spec.rb
+++ b/spec/rainforest_cli/test_parser_spec.rb
@@ -2,13 +2,34 @@
 describe RainforestCli::TestParser do
   describe RainforestCli::TestParser::Parser do
     subject { described_class.new(file_name) }
+    let(:file_name) { './spec/rainforest-example/example_test.rfml' }
 
     describe '#initialize' do
-      let(:file_name) { './spec/rainforest-example/example_test.rfml' }
-
       it 'expands the file name path' do
         test = subject.instance_variable_get(:@test)
         expect(test.file_name).to eq(File.expand_path(file_name))
+      end
+    end
+
+    describe '#process' do
+      let(:parsed_test) { subject.process }
+      let(:parsed_step) { parsed_test.steps.first }
+
+      describe 'parsing comments' do
+        it 'properly identifies comments' do
+          expect(parsed_test.description).to include('This is a comment', 'this is also a comment')
+        end
+
+        it 'properly identifies metadata fields' do
+          expect(parsed_test.title).to eq('Example Test')
+          expect(parsed_test.tags).to eq(['foo', 'bar', 'baz'])
+          expect(parsed_test.site_id).to eq('456')
+          expect(parsed_test.start_uri).to eq('/start_uri')
+        end
+
+        it 'properly parses step metadata' do
+          expect(parsed_step.redirect).to eq('false')
+        end
       end
     end
   end


### PR DESCRIPTION
We no longer need to save test meta-data in the notes section, just regular notes.