### PR TITLE
[Review] JUnit Reports in Go

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ tmp
 tags
 
 *.csv
+example.xml
 spec/rainforest
 spec/rainforest-testing
 

--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,7 @@ tmp
 tags
 
 *.csv
-example.xml
+*.xml
 spec/rainforest
 spec/rainforest-testing
 

--- a/README.md
+++ b/README.md
@@ -27,11 +27,6 @@ To use the cli client, you'll need your API token from a test settings page from
 
 You can either pass the token with `--token YOUR_TOKEN_HERE` CLI option, or put it in the `RAINFOREST_API_TOKEN` environment variable.
 
-You can customize the amount of threads to use when making HTTP requests by setting the
-`RAINFOREST_THREADS` to the number of threads you'd like to use. If you are noticing
-API errors when fetching or updating multiple tests, lowering this value can help.
-The default value is `16`.
-
 ## Options
 
 #### Running Tests

--- a/README.md
+++ b/README.md
@@ -27,13 +27,22 @@ To use the cli client, you'll need your API token from a test settings page from
 
 You can either pass the token with `--token YOUR_TOKEN_HERE` CLI option, or put it in the `RAINFOREST_API_TOKEN` environment variable.
 
-Run all of your tests
+You can customize the amount of threads to use when making HTTP requests by setting the
+`RAINFOREST_THREADS` to the number of threads you'd like to use. If you are noticing
+API errors when fetching or updating multiple tests, lowering this value can help.
+The default value is `16`.
+
+## Options
+
+#### Running Tests
+
+Run all tests.
 
 ```bash
 rainforest run all
 ```
 
-Run all in the foreground and report
+Run all in the foreground and report.
 
 ```bash
 rainforest run all --fg
@@ -45,10 +54,32 @@ Run all tests with tag 'run-me' and abort previous in-progress runs.
 rainforest run --tag run-me --fg --conflict abort
 ```
 
+Run all in the foreground and generate a junit xml report.
+
+```bash
+rainforest run all --fg --junit-file rainforest.xml
+```
+
+#### Creating and Managing Tests
+
 Create new Rainforest test in RFML format (Rainforest Markup Language).
 
 ```bash
 rainforest new
+```
+
+You may also specify a custom test title or file name.
+
+```bash
+rainforest new "My Awesome Title"
+```
+
+Validate your tests for syntax and correct RFML ids for embedded tests.
+Use the `--token` options or `RAINFOREST_API_TOKEN` environment variable
+to validate your tests against server data as well.
+
+```bash
+rainforest validate
 ```
 
 Upload tests to Rainforest
@@ -57,10 +88,31 @@ Upload tests to Rainforest
 rainforest upload
 ```
 
+Upload a specific test to Rainforest
+
+```bash
+rainforest upload /path/to/test/file.rfml
+```
+
+Remove RFML file and remove test from Rainforest test suite.
+
+```bash
+rainforest rm /path/to/test/file.rfml
+```
+
 Export all tests from Rainforest
+
 ```bash
 rainforest export
 ```
+
+Export tests filtered by tags, site, and smart folder
+
+```bash
+rainforest export --tag foo --tag bar --site-id 123 --folder 456
+```
+
+#### Viewing Account Specific Information
 
 See a list of all of your sites and their IDs
 ```bash
@@ -75,6 +127,23 @@ rainforest folders
 See a list of all of your browsers and their IDs
 ```bash
 rainforest browsers
+```
+
+To generate a junit xml report for a test run which has already completed
+```bash
+rainforest report <run-id> --junit-file rainforest.xml
+```
+
+#### Updating Tabular Variables
+
+Upload a CSV to create a new tabular variables.
+```bash
+rainforest csv-upload --import-variable-csv-file PATH/TO/CSV.csv --import-variable-name my_variable
+```
+
+Upload a CSV to update an existing tabular variables.
+```bash
+rainforest csv-upload --import-variable-csv-file PATH/TO/CSV.csv --import-variable-name my_variable --overwrite-variable
 ```
 
 ## Options
@@ -101,8 +170,11 @@ Rainforest Tests written using RFML have the following format
 # redirect: [REDIRECT FLAG]
 - [EMBEDDED TEST RFML ID]
 
-[ACTION 2]
-[QUESTION 2]
+Action with an embedded screenshot: {{ file.screenshot(./relative/path/to/screenshot.jpg) }}
+Response with an embedded file download: {{ file.download(./relative/path/to/file.txt) }}
+
+[ACTION 3]
+[QUESTION 3]
 
 ... etc.
 ```
@@ -134,18 +206,22 @@ tests and the first step of a test.
 - `EMBEDDED TEST RFML ID` - Embed the steps of another test within the current test
 using the embedded test's RFML ID.
 
+For more information on embedding inline screenshots and file downloads,
+[see our examples](./examples/inline_files.md)
+
 For more information on test writing, please visit our [documentation](http://support.rainforestqa.com/hc/en-us/sections/200585603-Writing-Tests).
 
 ### Command Line Options
 
 Popular command line options are:
 - `--browsers ie8` or `--browsers ie8,chrome` - specify the browsers you wish to run against. This overrides the test own settings. Valid browsers can be found in your account settings.
-- `--tag run-me` - only run tests which have this tag (recommended if you have lots of [test-steps](http://docs.rainforestqa.com/pages/example-test-suite.html#test_steps))!)
-- `--site-id` - only run tests for a specific site. Get in touch with us for help on getting that you site id if you are unable to.
-- `--folder ID` - run tests in specified folder.
+- `--tag TAG_NAME` - filter tests by tag. Can be used multiple times for filtering by multiple tags.
+- `--site-id SITE_ID` - filter tests by a specific site. You can see a list of your site IDs with `rainforest sites`.
+- `--folder ID` - filter tests in specified folder.
 - `--environment-id` - run your tests using this environment. Otherwise it will use your default environment
 - `--conflict OPTION` - use the `abort` option to abort any runs in progress in the same environment as your new run. use the `abort-all` option to abort all runs in progress.
 - `--fg` - results in the foreground - rainforest-cli will not return until the run is complete. This is what you want to make the build pass / fail dependent on rainforest results
+- `--wait RUN_ID` - wait for an existing run to finish instead of starting a new one, and exit with a non-0 code if the run fails. rainforest-cli will exit immediately if the run is already complete.
 - `--fail-fast` - fail the build as soon as the first failed result comes in. If you don't pass this it will wait until 100% of the run is done. Use with `--fg`.
 - `--custom-url` - use a custom url for this run. Example use case: an ad-hoc QA environment with [Fourchette](https://github.com/rainforestapp/fourchette). You will need to specify a `site_id` too for this to work. Note that we will be creating a new environment for this particular run.
 - `--git-trigger` - only trigger a run when the last commit (for a git repo in the current working directory) has contains `@rainforest` and a list of one or more tags. E.g. "Fix checkout process. @rainforest #checkout" would trigger a run for everything tagged `checkout`. This over-rides `--tag` and any tests specified. If no `@rainforest` is detected it will exit 0.
@@ -153,7 +229,64 @@ Popular command line options are:
 - `--embed-tests` - Use with `rainforest export` to export your tests without extracting the
 steps of an embedded test.
 - `--test-folder /path/to/directory` - Use with `rainforest [new, upload, export]`. If this option is not provided, rainforest-cli will, in the case of 'new' create a directory, or in the case of 'upload' and 'export' use the directory, at the default path `./spec/rainforest/`.
+- `--junit-file` - Create a junit xml report file with the specified name.  Must be run in foreground mode, or with the report command. Uses the rainforest
+api to construct a junit report.  This is useful to track tests in CI such as Jenkins or Bamboo.
+- `--run-id` - Only used with the report command.  Specify a past rainforest run by ID number to generate a report for.
+- `--import-variable-csv-file /path/to/csv/file.csv` - Use with `run` and `--import-variable-name` to upload new tabular variable values before your run to specify the path to your CSV file. You may also use this with the `csv-upload` command to update your variable before a run.
+- `--import-variable-name NAME` - Use with `run` and `--import-variable-csv-file` to upload new tabular variable values before your run to specify the name of your tabular variable. You may also use this with the `csv-upload` command to update your variable before a run.
+- `--single-use` - Use with `run` or `csv-upload` to flag your variable upload as `single-use`. See `--import-variable-csv-file` and `--import-variable-name` options as well.
 
+###Site-ID
+Only run tests for a specific site. Get in touch with us for help on getting that you site id if you are unable to.
+
+<pre>--site-id <b>ID</b></pre>
+
+###Folder-ID
+Run tests in specified folder.
+<pre>--folder <b>ID</b></pre>
+
+###Environment-ID
+run your tests using this environment. Otherwise it will use your default environment
+<pre>--environment-id <b>ID</b></pre>
+
+###Crowd
+<pre>--crowd [<b>default</b>|<b>on_premise_crowd</b>]</pre>
+
+###Conflict
+Use the abort option to abort any runs in progress in the same environment as your new run. use the abort-all option to abort all runs in progress.
+<pre>--conflict <b>option</b></pre> </pre>
+
+###Foreground
+Results in the foreground - rainforest-cli will not return until the run is complete. This is what you want to make the build pass / fail dependent on rainforest results
+<pre>--fg</pre>
+
+###Wait
+Wait for an existing run to finish instead of starting a new one, and exit with a non-0 code if the run fails. rainforest-cli will exit immediately if the run is already complete.
+<pre>--wait <b>RUN_ID</b></pre>
+
+###Fail-fast
+fail the build as soon as the first failed result comes in. If you don't pass this it will wait until 100% of the run is done. Use with --fg.
+<pre>--fail-fast</pre>
+###Custom URL
+
+use a custom url for this run. Example use case: an ad-hoc QA environment with Fourchette. You will need to specify a site_id too for this to work. Note that we will be creating a new environment for this particular run.
+<pre>--custom-url</pre>
+
+###Git-trigger
+only trigger a run when the last commit (for a git repo in the current working directory) has contains @rainforest and a list of one or more tags. E.g. "Fix checkout process. @rainforest #checkout" would trigger a run for everything tagged checkout. This over-rides --tag and any tests specified. If no @rainforest is detected it will exit 0.
+<pre>--git-trigger</pre>
+
+###Description "CI automatic run"
+add an arbitrary description for the run.
+<pre>--description "CI automatic run"</pre>
+
+###Embed-tests
+Use with rainforest export to export your tests without extracting the steps of an embedded test.
+<pre>--embed-tests</pre>
+
+###Test-folder
+Use with rainforest [new, upload, export]. If this option is not provided, rainforest-cli will, in the case of 'new' create a directory, or in the case of 'upload' and 'export' use the directory, at the default path ./spec/rainforest/.
+<pre>--test-folder /path/to/directory</pre>
 
 #### Specifying Test IDs
 Any integers input as arguments in the command line arguments are treated as
@@ -165,7 +298,7 @@ test IDs taken from the Rainforest dashboard. ie:
 All other argument types should be specified as seen above.
 
 
-More detailed info on options can be [found here](https://github.com/rainforestapp/rainforest-cli/blob/master/lib/rainforest/cli/options.rb#L23-L74).
+More detailed info on options can be [found here](https://github.com/rainforestapp/rainforest-cli/blob/master/lib/rainforest_cli/options.rb#L23-L74).
 
 ## Support
 

--- a/rainforest-cli.go
+++ b/rainforest-cli.go
@@ -279,22 +279,21 @@ func main() {
 		},
 		{
 			Name:  "report",
-			Usage: "Create a JUnit report from your run results",
-			Description: "Creates a JUnit report from your specified run." +
+			Usage: "Create a report from your run results",
+			Description: "Creates a report from your specified run." +
 				"You can specify output file using options, otherwise report will be generated to STDOUT",
 			ArgsUsage: "[run ID]",
 			Flags: []cli.Flag{
 				cli.StringFlag{
-					Name:  "junit-file, out, o",
-					Usage: "`PATH` of file to which save the JUnit report.",
+					Name:  "junit-file",
+					Usage: "`PATH` of file to which write a JUnit report for the specified run.",
 				},
-				// Left here for legacy reason, but imho we should move that to args
 				cli.StringFlag{
 					Name:  "run-id",
 					Usage: "DEPRECATED: ID of a run for which to generate results. Since v2 please provide the run ID as an argument.",
 				},
 			},
-			Action: notImplemented,
+			Action: reportForRun,
 		},
 		{
 			Name:  "sites",

--- a/rainforest-cli.go
+++ b/rainforest-cli.go
@@ -293,7 +293,7 @@ func main() {
 					Usage: "DEPRECATED: ID of a run for which to generate results. Since v2 please provide the run ID as an argument.",
 				},
 			},
-			Action: createReports,
+			Action: createReport,
 		},
 		{
 			Name:  "sites",

--- a/rainforest-cli.go
+++ b/rainforest-cli.go
@@ -16,6 +16,9 @@ const (
 
 	// Run status poll interval
 	runStatusPollInterval = time.Second * 5
+
+	// Maximum concurrency for multithreaded HTTP requests
+	maxWebConcurrency = 4
 )
 
 var (
@@ -74,12 +77,6 @@ func main() {
 			Name:   "token, t",
 			Usage:  "API token. You can find it at https://app.rainforestqa.com/settings/integrations",
 			EnvVar: "RAINFOREST_API_TOKEN",
-		},
-		cli.IntFlag{
-			Name:   "threads",
-			Usage:  "Used to customize the amount of concurrent HTTP connections to use.",
-			Value:  16,
-			EnvVar: "RAINFOREST_THREADS",
 		},
 	}
 

--- a/rainforest-cli.go
+++ b/rainforest-cli.go
@@ -293,7 +293,7 @@ func main() {
 					Usage: "DEPRECATED: ID of a run for which to generate results. Since v2 please provide the run ID as an argument.",
 				},
 			},
-			Action: reportForRun,
+			Action: createReports,
 		},
 		{
 			Name:  "sites",

--- a/rainforest/rainforest.go
+++ b/rainforest/rainforest.go
@@ -71,7 +71,7 @@ func (c *Client) NewRequest(method, urlStr string, body interface{}) (*http.Requ
 	var b io.ReadWriter
 	if body != nil {
 		b = new(bytes.Buffer)
-		err := json.NewEncoder(b).Encode(body)
+		err = json.NewEncoder(b).Encode(body)
 		if err != nil {
 			return nil, err
 		}

--- a/rainforest/rainforest_test.go
+++ b/rainforest/rainforest_test.go
@@ -35,7 +35,7 @@ func cleanup() {
 
 func TestNewClient(t *testing.T) {
 	token := "testToken123"
-	client := NewClient(token)
+	client = NewClient(token)
 	if out := client.ClientToken; client.ClientToken != token {
 		t.Errorf("NewClient didn't set proper token %+v, want %+v", out, token)
 	}
@@ -43,7 +43,7 @@ func TestNewClient(t *testing.T) {
 
 func TestNewRequest(t *testing.T) {
 	token := "testToken123"
-	client := NewClient(token)
+	client = NewClient(token)
 	client.BaseURL, _ = url.Parse("https://example.org")
 	req, _ := client.NewRequest("GET", "test", nil)
 	if out := req.Header.Get(authTokenHeader); out != token {

--- a/rainforest/reporter.go
+++ b/rainforest/reporter.go
@@ -1,0 +1,26 @@
+package rainforest
+
+import "strconv"
+
+// RunDetails contains top level details of a Run
+type RunDetails struct {
+	Description        string `json:"description"`
+	TotalTests         int    `json:"total_tests"`
+	TotalFailedTests   int    `json:"total_failed_tests"`
+	TotalNoResultTests int    `json:"total_no_result_tests"`
+}
+
+// GetRunDetails returns the top level details of a Run
+func (c *Client) GetRunDetails(runID int) (*RunDetails, error) {
+	var runDetails RunDetails
+	url := "runs/" + strconv.Itoa(runID)
+
+	req, err := c.NewRequest("GET", url, nil)
+	if err != nil {
+		return &runDetails, err
+	}
+
+	_, err = c.Do(req, &runDetails)
+
+	return &runDetails, err
+}

--- a/rainforest/reporter.go
+++ b/rainforest/reporter.go
@@ -1,6 +1,9 @@
 package rainforest
 
-import "strconv"
+import (
+	"strconv"
+	"time"
+)
 
 // RunFeedback contains details about the feedback of a Run Step for a browser
 type RunFeedback struct {
@@ -24,8 +27,8 @@ type RunStepDetails struct {
 type RunTestDetails struct {
 	ID        int              `json:"id"`
 	Title     string           `json:"title"`
-	CreatedAt string           `json:"created_at"`
-	UpdatedAt string           `json:"updated_at"`
+	CreatedAt time.Time        `json:"created_at"`
+	UpdatedAt time.Time        `json:"updated_at"`
 	Result    string           `json:"result"`
 	Steps     []RunStepDetails `json:"steps"`
 }
@@ -38,13 +41,13 @@ type RunStateDetails struct {
 
 // RunDetails contains top level details of a Run
 type RunDetails struct {
-	ID                 int               `json:"id"`
-	Description        string            `json:"description"`
-	TotalTests         int               `json:"total_tests"`
-	TotalFailedTests   int               `json:"total_failed_tests"`
-	TotalNoResultTests int               `json:"total_no_result_tests"`
-	StateDetails       RunStateDetails   `json:"state_details"`
-	Timestamps         map[string]string `json:"timestamps"`
+	ID                 int                  `json:"id"`
+	Description        string               `json:"description"`
+	TotalTests         int                  `json:"total_tests"`
+	TotalFailedTests   int                  `json:"total_failed_tests"`
+	TotalNoResultTests int                  `json:"total_no_result_tests"`
+	StateDetails       RunStateDetails      `json:"state_details"`
+	Timestamps         map[string]time.Time `json:"timestamps"`
 	Tests              []RunTestDetails
 }
 

--- a/rainforest/reporter.go
+++ b/rainforest/reporter.go
@@ -2,21 +2,43 @@ package rainforest
 
 import "strconv"
 
+// RunFeedback contains details about the feedback of a Run Step for a browser
+type RunFeedback struct {
+	AnswerGiven string `json:"answer_given"`
+	JobState    string `json:"job_state"`
+	Note        string `json:"note"`
+}
+
+// RunBrowserDetails contains details about a Browser of a Run Step
+type RunBrowserDetails struct {
+	Name     string        `json:"name"`
+	Feedback []RunFeedback `json:"feedback"`
+}
+
+// RunStepDetails contains details about a Run Step
+type RunStepDetails struct {
+	Browsers []RunBrowserDetails `json:"browsers"`
+}
+
+// RunTestDetails contains details about a Run Test
+type RunTestDetails struct {
+	ID        int              `json:"id"`
+	Title     string           `json:"title"`
+	CreatedAt string           `json:"created_at"`
+	UpdatedAt string           `json:"updated_at"`
+	Result    string           `json:"result"`
+	Steps     []RunStepDetails `json:"steps"`
+}
+
 // RunStateDetails contains details about the state of a Run
 type RunStateDetails struct {
 	Name         string `json:"name"`
 	IsFinalState bool   `json:"is_final_state"`
 }
 
-// RunTestDetails contains details about a specific Run Test
-type RunTestDetails struct {
-	Title     string `json:"title"`
-	CreatedAt string `json:"created_at"`
-	UpdatedAt string `json:"updated_at"`
-}
-
 // RunDetails contains top level details of a Run
 type RunDetails struct {
+	ID                 int               `json:"id"`
 	Description        string            `json:"description"`
 	TotalTests         int               `json:"total_tests"`
 	TotalFailedTests   int               `json:"total_failed_tests"`
@@ -60,4 +82,22 @@ func (c *Client) GetRunDetails(runID int) (*RunDetails, error) {
 	runDetails.Tests = runTests
 
 	return &runDetails, err
+}
+
+// GetRunTestDetails returns the detailed information for a RunTest
+func (c *Client) GetRunTestDetails(runID int, testID int) (*RunTestDetails, error) {
+	var runTestDetails RunTestDetails
+	url := "runs/" + strconv.Itoa(runID) + "/tests/" + strconv.Itoa(testID)
+
+	req, err := c.NewRequest("GET", url, nil)
+	if err != nil {
+		return &runTestDetails, err
+	}
+
+	_, err = c.Do(req, &runTestDetails)
+	if err != nil {
+		return &runTestDetails, err
+	}
+
+	return &runTestDetails, nil
 }

--- a/rainforest/reporter.go
+++ b/rainforest/reporter.go
@@ -63,7 +63,7 @@ func (c *Client) GetRunDetails(runID int) (*RunDetails, error) {
 		return &runDetails, err
 	}
 
-	// NOTE: This extra request is only necessary because `update_at` is not
+	// NOTE: This extra request is only necessary because `updated_at` is not
 	// currently exposed in the `/runs/:id` endpoint. This may change in the future:
 	// https://github.com/rainforestapp/rainforest-cli/issues/216
 	var runTests []RunTestDetails

--- a/rainforest/reporter.go
+++ b/rainforest/reporter.go
@@ -2,12 +2,20 @@ package rainforest
 
 import "strconv"
 
+// RunStateDetails contains details about the state of a Run
+type RunStateDetails struct {
+	Name         string `json:"name"`
+	IsFinalState bool   `json:"is_final_state"`
+}
+
 // RunDetails contains top level details of a Run
 type RunDetails struct {
-	Description        string `json:"description"`
-	TotalTests         int    `json:"total_tests"`
-	TotalFailedTests   int    `json:"total_failed_tests"`
-	TotalNoResultTests int    `json:"total_no_result_tests"`
+	Description        string            `json:"description"`
+	TotalTests         int               `json:"total_tests"`
+	TotalFailedTests   int               `json:"total_failed_tests"`
+	TotalNoResultTests int               `json:"total_no_result_tests"`
+	StateDetails       RunStateDetails   `json:"state_details"`
+	Timestamps         map[string]string `json:"timestamps"`
 }
 
 // GetRunDetails returns the top level details of a Run

--- a/rainforest/reporter.go
+++ b/rainforest/reporter.go
@@ -16,6 +16,12 @@ type RunDetails struct {
 	TotalNoResultTests int               `json:"total_no_result_tests"`
 	StateDetails       RunStateDetails   `json:"state_details"`
 	Timestamps         map[string]string `json:"timestamps"`
+	Tests              []RunTestDetails  `json:"tests"`
+}
+
+// RunTestDetails contains details about a specific Run Test
+type RunTestDetails struct {
+	Title string `json:"title"`
 }
 
 // GetRunDetails returns the top level details of a Run

--- a/rainforest/reporter_test.go
+++ b/rainforest/reporter_test.go
@@ -2,7 +2,6 @@ package rainforest
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"reflect"
 	"strconv"
@@ -45,13 +44,12 @@ func TestGetRunDetails(t *testing.T) {
 		if r.Method != reqMethod {
 			t.Errorf("Unexpected request method in GetRunTestDetails. Expected: %v, Actual: %v", reqMethod, r.Method)
 		}
-		fmt.Println("Runs URL reached")
 
 		enc := json.NewEncoder(w)
 		enc.Encode(runDetails)
 	})
 
-	updatedAt := time.Now()
+	updatedAt, _ := time.Parse(time.RFC3339Nano, "2016-07-13T22:21:31.492Z")
 	createdAt := updatedAt.Add(-10 * time.Minute)
 	runTests := []RunTestDetails{
 		{
@@ -103,7 +101,7 @@ func TestGetRunTestDetails(t *testing.T) {
 	testID := 456
 	reqMethod := "GET"
 
-	updatedAt := time.Now()
+	updatedAt, _ := time.Parse(time.RFC3339Nano, "2016-07-13T22:21:31.492Z")
 	createdAt := updatedAt.Add(-10 * time.Minute)
 	runTest := RunTestDetails{
 		ID:        runID,

--- a/rainforest/reporter_test.go
+++ b/rainforest/reporter_test.go
@@ -2,11 +2,90 @@ package rainforest
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"reflect"
 	"strconv"
 	"testing"
 )
+
+func TestGetRunDetails(t *testing.T) {
+	setup()
+	defer cleanup()
+
+	runID := 1337
+	reqMethod := "GET"
+	runsURL := "/runs/" + strconv.Itoa(runID)
+
+	runDetails := RunDetails{
+		ID:                 runID,
+		Description:        "run description",
+		TotalTests:         10,
+		TotalFailedTests:   2,
+		TotalNoResultTests: 1,
+		StateDetails: RunStateDetails{
+			Name:         "aborted",
+			IsFinalState: true,
+		},
+		Timestamps: map[string]string{
+			"complete":    "2016-07-13T22:21:31.492Z",
+			"in_progress": "2016-07-13T22:06:18.279Z",
+			"validating":  "2016-07-13T22:06:12.411Z",
+			"created_at":  "2016-07-13T22:06:10.034Z",
+		},
+	}
+
+	mux.HandleFunc(runsURL, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != reqMethod {
+			t.Errorf("Unexpected request method in GetRunTestDetails. Expected: %v, Actual: %v", reqMethod, r.Method)
+		}
+		fmt.Println("Runs URL reached")
+
+		enc := json.NewEncoder(w)
+		enc.Encode(runDetails)
+	})
+
+	runTests := []RunTestDetails{
+		{
+			ID:        999,
+			Title:     "Run test title",
+			CreatedAt: "2016-07-13T22:06:10.034Z",
+			UpdatedAt: "2016-07-13T22:21:31.492Z",
+			Result:    "failed",
+		},
+	}
+
+	testsURL := "/runs/" + strconv.Itoa(runID) + "/tests"
+	mux.HandleFunc(testsURL, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != reqMethod {
+			t.Errorf("Unexpected request method in GetRunTestDetails. Expected: %v, Actual: %v", reqMethod, r.Method)
+		}
+
+		enc := json.NewEncoder(w)
+		enc.Encode(runTests)
+	})
+
+	out, err := client.GetRunDetails(runID)
+
+	if err != nil {
+		t.Errorf("Unexpected error in GetRunTestDetails: %v", err)
+	}
+
+	expectedRunDetails := RunDetails{
+		ID:                 runDetails.ID,
+		Description:        runDetails.Description,
+		TotalTests:         runDetails.TotalTests,
+		TotalFailedTests:   runDetails.TotalFailedTests,
+		TotalNoResultTests: runDetails.TotalNoResultTests,
+		StateDetails:       runDetails.StateDetails,
+		Timestamps:         runDetails.Timestamps,
+		Tests:              runTests,
+	}
+
+	if !reflect.DeepEqual(expectedRunDetails, *out) {
+		t.Errorf("Unexpected return value from GetRunDetails.\nExpected: %#v\nGot: %#v", expectedRunDetails, *out)
+	}
+}
 
 func TestGetRunTestDetails(t *testing.T) {
 	setup()
@@ -56,7 +135,11 @@ func TestGetRunTestDetails(t *testing.T) {
 		enc.Encode(runTest)
 	})
 
-	out, _ := client.GetRunTestDetails(runID, testID)
+	out, err := client.GetRunTestDetails(runID, testID)
+
+	if err != nil {
+		t.Errorf("Unexpected error in GetRunTestDetails: %v", err)
+	}
 
 	if !reflect.DeepEqual(runTest, *out) {
 		t.Errorf("Unexpected return value from GetRunTestDetails.\nExpected: %#v\nGot: %#v", runTest, *out)

--- a/rainforest/reporter_test.go
+++ b/rainforest/reporter_test.go
@@ -1,0 +1,64 @@
+package rainforest
+
+import (
+	"encoding/json"
+	"net/http"
+	"reflect"
+	"strconv"
+	"testing"
+)
+
+func TestGetRunTestDetails(t *testing.T) {
+	setup()
+	defer cleanup()
+
+	runID := 123
+	testID := 456
+	reqMethod := "GET"
+
+	runTest := RunTestDetails{
+		ID:        runID,
+		Title:     "my test title",
+		CreatedAt: "2016-07-13T22:00:00Z",
+		UpdatedAt: "2016-07-13T22:10:00Z",
+		Result:    "passed",
+		Steps: []RunStepDetails{
+			{
+				Browsers: []RunBrowserDetails{
+					{
+						Name: "chrome",
+						Feedback: []RunFeedback{
+							{
+								AnswerGiven: "no",
+								JobState:    "approved",
+								Note:        "did not work",
+							},
+							{
+								AnswerGiven: "yes",
+								JobState:    "rejected",
+								Note:        "it worked",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// TODO: Find the correct pattern for this
+	url := "/runs/" + strconv.Itoa(runID) + "/tests/" + strconv.Itoa(testID)
+	mux.HandleFunc(url, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != reqMethod {
+			t.Errorf("Unexpected request method in GetRunTestDetails. Expected: %v, Actual: %v", reqMethod, r.Method)
+		}
+
+		enc := json.NewEncoder(w)
+		enc.Encode(runTest)
+	})
+
+	out, _ := client.GetRunTestDetails(runID, testID)
+
+	if !reflect.DeepEqual(runTest, *out) {
+		t.Errorf("Unexpected return value from GetRunTestDetails.\nExpected: %#v\nGot: %#v", runTest, *out)
+	}
+}

--- a/rainforest/reporter_test.go
+++ b/rainforest/reporter_test.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"strconv"
 	"testing"
+	"time"
 )
 
 func TestGetRunDetails(t *testing.T) {
@@ -16,6 +17,11 @@ func TestGetRunDetails(t *testing.T) {
 	runID := 1337
 	reqMethod := "GET"
 	runsURL := "/runs/" + strconv.Itoa(runID)
+
+	completeTime, _ := time.Parse(time.RFC3339Nano, "2016-07-13T22:21:31.492Z")
+	inProgressTime, _ := time.Parse(time.RFC3339Nano, "2016-07-13T22:06:18.279Z")
+	validatingTime, _ := time.Parse(time.RFC3339Nano, "2016-07-13T22:06:12.411Z")
+	createdAtTime, _ := time.Parse(time.RFC3339Nano, "2016-07-13T22:06:10.034Z")
 
 	runDetails := RunDetails{
 		ID:                 runID,
@@ -27,11 +33,11 @@ func TestGetRunDetails(t *testing.T) {
 			Name:         "aborted",
 			IsFinalState: true,
 		},
-		Timestamps: map[string]string{
-			"complete":    "2016-07-13T22:21:31.492Z",
-			"in_progress": "2016-07-13T22:06:18.279Z",
-			"validating":  "2016-07-13T22:06:12.411Z",
-			"created_at":  "2016-07-13T22:06:10.034Z",
+		Timestamps: map[string]time.Time{
+			"complete":    completeTime,
+			"in_progress": inProgressTime,
+			"validating":  validatingTime,
+			"created_at":  createdAtTime,
 		},
 	}
 
@@ -45,12 +51,14 @@ func TestGetRunDetails(t *testing.T) {
 		enc.Encode(runDetails)
 	})
 
+	updatedAt := time.Now()
+	createdAt := updatedAt.Add(-10 * time.Minute)
 	runTests := []RunTestDetails{
 		{
 			ID:        999,
 			Title:     "Run test title",
-			CreatedAt: "2016-07-13T22:06:10.034Z",
-			UpdatedAt: "2016-07-13T22:21:31.492Z",
+			CreatedAt: createdAt,
+			UpdatedAt: updatedAt,
 			Result:    "failed",
 		},
 	}
@@ -95,11 +103,13 @@ func TestGetRunTestDetails(t *testing.T) {
 	testID := 456
 	reqMethod := "GET"
 
+	updatedAt := time.Now()
+	createdAt := updatedAt.Add(-10 * time.Minute)
 	runTest := RunTestDetails{
 		ID:        runID,
 		Title:     "my test title",
-		CreatedAt: "2016-07-13T22:00:00Z",
-		UpdatedAt: "2016-07-13T22:10:00Z",
+		CreatedAt: createdAt,
+		UpdatedAt: updatedAt,
 		Result:    "passed",
 		Steps: []RunStepDetails{
 			{

--- a/reporter.go
+++ b/reporter.go
@@ -68,6 +68,8 @@ func (r *reporter) createReport(c cliContext) error {
 }
 
 func (r *reporter) createJUnitReport(runID int, junitFile string) error {
+	log.Print("Creating JUnit report for run #" + strconv.Itoa(runID) + ": " + junitFile)
+
 	if filepath.Ext(junitFile) != ".xml" {
 		return fmt.Errorf("JUnit file extension must be .xml")
 	}
@@ -106,6 +108,8 @@ func (r *reporter) createJUnitReport(runID int, junitFile string) error {
 func getRunDetails(runID int, client *rainforest.Client) (*rainforest.RunDetails, error) {
 	var runDetails *rainforest.RunDetails
 	var err error
+
+	log.Printf("Fetching details for run #" + strconv.Itoa(runID))
 	if runDetails, err = client.GetRunDetails(runID); err != nil {
 		return runDetails, err
 	}
@@ -197,6 +201,7 @@ func createJunitTestReportSchema(runID int, tests *[]rainforest.RunTestDetails, 
 
 			// reserve a thread
 			httpThreads <- struct{}{}
+			log.Printf("Fetching information for failed test #" + strconv.Itoa(test.ID))
 			testDetails, err = client.GetRunTestDetails(runID, test.ID)
 			// release the thread
 			<-httpThreads
@@ -252,6 +257,8 @@ func writeJUnitReport(reportSchema *jUnitReportSchema, file *os.File) error {
 	if err != nil {
 		return err
 	}
+
+	log.Printf("JUnit report successfully written to %v", file.Name())
 
 	return nil
 }

--- a/reporter.go
+++ b/reporter.go
@@ -1,28 +1,55 @@
 package main
 
 import (
+	"fmt"
 	"io/ioutil"
 	"log"
 	"path/filepath"
+	"strconv"
 
 	"github.com/rainforestapp/rainforest-cli/rainforest"
 	"github.com/urfave/cli"
 )
 
 func reportForRun(c *cli.Context) error {
+	var runID int
+	var err error
+
+	if runIDArg := c.Args().Get(0); runIDArg != "" {
+		runID, err = strconv.Atoi(runIDArg)
+		if err != nil {
+			return err
+		}
+	} else if deprecatedRunIDArg := c.String("run-id"); deprecatedRunIDArg != "" {
+		runID, err = strconv.Atoi(deprecatedRunIDArg)
+		if err != nil {
+			return err
+		}
+
+		log.Println("Warning - `run-id` flag is deprecated. Please provide Run ID as an argument.")
+	} else {
+		return cli.NewExitError("No run found.", 1)
+	}
+
 	if junitFile := c.String("junit-file"); junitFile != "" {
-		createJunitReport(junitFile, api)
+		err = createJunitReport(junitFile, runID, api)
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil
 }
 
-func createJunitReport(filename string, api *rainforest.Client) {
+func createJunitReport(filename string, runID int, api *rainforest.Client) error {
 	filepath, err := filepath.Abs(filename)
 
 	if err != nil {
-		log.Fatalf("Error parsing file path: %v", err)
+		return err
 	}
 
-	ioutil.WriteFile(filepath, []byte("this is a test"), 0777)
+	output := fmt.Sprintf("Info for run #%v", runID)
+	ioutil.WriteFile(filepath, []byte(output), 0777)
+
+	return nil
 }

--- a/reporter.go
+++ b/reporter.go
@@ -2,11 +2,11 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"path/filepath"
 	"strconv"
 
+	"github.com/rainforestapp/rainforest-cli/rainforest"
 	"github.com/urfave/cli"
 )
 
@@ -15,7 +15,9 @@ type reporterCliContext interface {
 	Args() (args cli.Args)
 }
 
-type reporterClient interface{}
+type reporterClient interface {
+	GetRunDetails(runID int) (*rainforest.RunDetails, error)
+}
 
 type reporter struct {
 	createJunitReport func(filename string, runID int, client reporterClient) error
@@ -66,11 +68,22 @@ func createJunitReport(filename string, runID int, client reporterClient) error 
 	filepath, err := filepath.Abs(filename)
 
 	if err != nil {
+		log.Fatalf("Error parsing file path `%v`: %v", filepath, err.Error())
 		return err
 	}
 
-	output := fmt.Sprintf("Info for run #%v", runID)
-	ioutil.WriteFile(filepath, []byte(output), 0777)
+	var runDetails *rainforest.RunDetails
+	runDetails, err = client.GetRunDetails(runID)
+
+	if err != nil {
+		log.Fatalf("Error fetching details for run #%v: %v", runID, err.Error())
+		return err
+	}
+
+	fmt.Println(filepath)
+	fmt.Println(runDetails)
+	// output := fmt.Sprintf("Info for run #%v", runID)
+	// ioutil.WriteFile(filepath, []byte(output), 0777)
 
 	return nil
 }

--- a/reporter.go
+++ b/reporter.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"io/ioutil"
+	"log"
+	"path/filepath"
+
+	"github.com/rainforestapp/rainforest-cli/rainforest"
+	"github.com/urfave/cli"
+)
+
+func reportForRun(c *cli.Context) error {
+	if junitFile := c.String("junit-file"); junitFile != "" {
+		createJunitReport(junitFile, api)
+	}
+
+	return nil
+}
+
+func createJunitReport(filename string, api *rainforest.Client) {
+	filepath, err := filepath.Abs(filename)
+
+	if err != nil {
+		log.Fatalf("Error parsing file path: %v", err)
+	}
+
+	ioutil.WriteFile(filepath, []byte("this is a test"), 0777)
+}

--- a/reporter.go
+++ b/reporter.go
@@ -262,6 +262,7 @@ func writeJUnitReport(reportSchema *jUnitReportSchema, file *os.File) error {
 
 	log.Printf("JUnit report successfully written to %v", file.Name())
 
+	file.Close()
 	return nil
 }
 

--- a/reporter_test.go
+++ b/reporter_test.go
@@ -47,7 +47,7 @@ func TestReporterCreateReport(t *testing.T) {
 		return os.NewFile(1, "test"), nil
 	}
 
-	r.createJunitReportSchema = func(*rainforest.RunDetails) (*jUnitReportSchema, error) {
+	r.createJunitReportSchema = func(*rainforest.RunDetails, *rainforest.Client) (*jUnitReportSchema, error) {
 		return &jUnitReportSchema{}, nil
 	}
 

--- a/reporter_test.go
+++ b/reporter_test.go
@@ -10,11 +10,11 @@ import (
 	"github.com/urfave/cli"
 )
 
-func TestReporterReportForRun(t *testing.T) {
+func TestReporterCreateReport(t *testing.T) {
 	r := newReporter()
 	c := newFakeContext(make(map[string]interface{}), cli.Args{})
 
-	err := r.reportForRun(c)
+	err := r.createReport(c)
 
 	if err == nil {
 		t.Error("No error produced in reporter.reportForRun when Run ID is omitted")
@@ -47,7 +47,11 @@ func TestReporterReportForRun(t *testing.T) {
 		return os.NewFile(1, "test"), nil
 	}
 
-	r.writeJUnitReport = func(*rainforest.RunDetails, *os.File) error {
+	r.createJunitReportSchema = func(*rainforest.RunDetails) (*jUnitReportSchema, error) {
+		return &jUnitReportSchema{}, nil
+	}
+
+	r.writeJUnitReport = func(*jUnitReportSchema, *os.File) error {
 		return nil
 	}
 
@@ -81,6 +85,6 @@ func TestReporterReportForRun(t *testing.T) {
 		expectedRunID = testCase.runID
 		expectedFileName = testCase.filename
 
-		r.reportForRun(c)
+		r.createReport(c)
 	}
 }

--- a/reporter_test.go
+++ b/reporter_test.go
@@ -1,0 +1,6 @@
+package main
+
+import "testing"
+
+func TestReportForRun(t *testing.T) {
+}

--- a/reporter_test.go
+++ b/reporter_test.go
@@ -1,6 +1,90 @@
 package main
 
-import "testing"
+import (
+	"testing"
 
-func TestReportForRun(t *testing.T) {
+	"github.com/urfave/cli"
+)
+
+type reporterFakeContext struct {
+	mappings              map[string]interface{}
+	args                  cli.Args
+	createJunitReportStub func(filename string, runID int)
+}
+
+func (c reporterFakeContext) String(s string) string {
+	val, ok := c.mappings[s].(string)
+
+	if ok {
+		return val
+	}
+	return ""
+}
+
+func (c reporterFakeContext) Args() cli.Args {
+	return c.args
+}
+
+func TestReporterReportForRun(t *testing.T) {
+	r := newReport()
+	c := reporterFakeContext{}
+
+	err := r.reportForRun(c)
+
+	if err == nil {
+		t.Error("No error produced in reporter.reportForRun when Run ID is omitted")
+	} else {
+		if err.Error() != "No run ID argument found." {
+			t.Errorf("Unexpected error in reporter.reportForRun when Run ID is omitted: %v", err.Error())
+		}
+	}
+
+	var expectedFileName string
+	var expectedRunID int
+
+	r.createJunitReport = func(filename string, runID int, client reporterClient) error {
+		if filename != expectedFileName {
+			t.Errorf("Unexpected filename given to createJunitReport.\nExpected: %v\nActual: %v", expectedFileName, filename)
+		}
+
+		if runID != expectedRunID {
+			t.Errorf("Unexpected run ID given to createJunitReport.\nExpected: %v\nActual: %v", expectedRunID, runID)
+		}
+
+		return nil
+	}
+
+	testCases := []struct {
+		mappings map[string]interface{}
+		args     []string
+		runID    int
+		filename string
+	}{
+		{
+			mappings: map[string]interface{}{
+				"junit-file": "myfilename",
+			},
+			args:     []string{"112233"},
+			runID:    112233,
+			filename: "myfilename",
+		},
+		{
+			mappings: map[string]interface{}{
+				"junit-file": "myfilename",
+				"run-id":     "112233",
+			},
+			args:     []string{},
+			runID:    112233,
+			filename: "myfilename",
+		},
+	}
+
+	for _, testCase := range testCases {
+		c.mappings = testCase.mappings
+		c.args = testCase.args
+		expectedRunID = testCase.runID
+		expectedFileName = testCase.filename
+
+		r.reportForRun(c)
+	}
 }

--- a/reporter_test.go
+++ b/reporter_test.go
@@ -15,7 +15,7 @@ import (
 func newFakeReporter() *reporter {
 	r := newReporter()
 
-	r.createJunitReportSchema = func(*rainforest.RunDetails, *rainforest.Client) (*jUnitReportSchema, error) {
+	r.createJUnitReportSchema = func(*rainforest.RunDetails, *rainforest.Client) (*jUnitReportSchema, error) {
 		return &jUnitReportSchema{}, nil
 	}
 
@@ -132,8 +132,8 @@ func TestCreateJunitTestReportSchema(t *testing.T) {
 
 	runID := 0 // Doesn't matter for this test
 	runTestTitle := "My title"
-	createdAt := "2016-07-13T22:00:00Z"
-	updatedAt := "2016-07-13T22:10:00Z"
+	updatedAt := time.Now()
+	createdAt := updatedAt.Add(-10 * time.Minute)
 
 	tests := []rainforest.RunTestDetails{
 		{

--- a/reporter_test.go
+++ b/reporter_test.go
@@ -10,27 +10,9 @@ import (
 	"github.com/urfave/cli"
 )
 
-type reporterFakeContext struct {
-	mappings map[string]interface{}
-	args     cli.Args
-}
-
-func (c reporterFakeContext) String(s string) string {
-	val, ok := c.mappings[s].(string)
-
-	if ok {
-		return val
-	}
-	return ""
-}
-
-func (c reporterFakeContext) Args() cli.Args {
-	return c.args
-}
-
 func TestReporterReportForRun(t *testing.T) {
 	r := newReporter()
-	c := reporterFakeContext{}
+	c := newFakeContext(make(map[string]interface{}), cli.Args{})
 
 	err := r.reportForRun(c)
 
@@ -95,8 +77,7 @@ func TestReporterReportForRun(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		c.mappings = testCase.mappings
-		c.args = testCase.args
+		c := newFakeContext(testCase.mappings, testCase.args)
 		expectedRunID = testCase.runID
 		expectedFileName = testCase.filename
 

--- a/runner.go
+++ b/runner.go
@@ -83,7 +83,7 @@ func updateRunStatus(c *cli.Context, runID int, t *time.Ticker, resChan chan sta
 	}
 }
 
-type cliContext interface {
+type runnerCliContext interface {
 	String(flag string) (val string)
 	StringSlice(flag string) (vals []string)
 	Args() (args cli.Args)
@@ -91,7 +91,7 @@ type cliContext interface {
 
 // makeRunParams parses and validates command line arguments + options
 // and makes RunParams struct out of them
-func makeRunParams(c cliContext) (rainforest.RunParams, error) {
+func makeRunParams(c runnerCliContext) (rainforest.RunParams, error) {
 	var err error
 
 	var smartFolderID int

--- a/runner.go
+++ b/runner.go
@@ -47,6 +47,8 @@ func startRun(c *cli.Context) error {
 			log.Printf("The detailed results are available at %v\n", finalState.status.FrontendURL)
 		}
 
+		postRunJUnitReport(c, runStatus.ID)
+
 		if finalState.status.Result != "passed" {
 			return cli.NewExitError("", 1)
 		}

--- a/runner_test.go
+++ b/runner_test.go
@@ -66,12 +66,12 @@ func TestExpandStringSlice(t *testing.T) {
 	}
 }
 
-type fakeContext struct {
+type runnerFakeContext struct {
 	mappings map[string]interface{}
 	args     cli.Args
 }
 
-func (f fakeContext) String(s string) string {
+func (f runnerFakeContext) String(s string) string {
 	val, ok := f.mappings[s].(string)
 
 	if ok {
@@ -80,7 +80,7 @@ func (f fakeContext) String(s string) string {
 	return ""
 }
 
-func (f fakeContext) StringSlice(s string) []string {
+func (f runnerFakeContext) StringSlice(s string) []string {
 	val, ok := f.mappings[s].([]string)
 
 	if ok {
@@ -89,12 +89,12 @@ func (f fakeContext) StringSlice(s string) []string {
 	return []string{}
 }
 
-func (f fakeContext) Args() cli.Args {
+func (f runnerFakeContext) Args() cli.Args {
 	return f.args
 }
 
 func TestMakeRunParams(t *testing.T) {
-	c := fakeContext{}
+	c := runnerFakeContext{}
 
 	var testCases = []struct {
 		mappings map[string]interface{}


### PR DESCRIPTION
Should be merged after #212 since this branch was based off of that.

TODO:
- [x] Add report to `run` command
- [x] Make HTTP requests concurrent
- [x] Add more tests

----------

Sample output of logs:
```
$ go build && ./rainforest-cli report 79593 --junit-file example.xml
2016/11/28 14:24:57 Creating JUnit report for run #79593: example.xml
2016/11/28 14:24:57 Fetching details for run #79593
2016/11/28 14:24:59 Fetching information for failed test #39168
2016/11/28 14:24:59 Fetching information for failed test #39176
2016/11/28 14:24:59 Fetching information for failed test #39185
2016/11/28 14:24:59 Fetching information for failed test #39178
2016/11/28 14:25:01 Fetching information for failed test #39182
2016/11/28 14:25:01 Fetching information for failed test #39181
2016/11/28 14:25:01 Fetching information for failed test #39194
2016/11/28 14:25:01 Fetching information for failed test #39193
2016/11/28 14:25:01 Fetching information for failed test #39196
2016/11/28 14:25:01 Fetching information for failed test #39187
2016/11/28 14:25:01 Fetching information for failed test #39180
2016/11/28 14:25:01 Fetching information for failed test #39192
2016/11/28 14:25:02 Fetching information for failed test #39183
2016/11/28 14:25:02 Fetching information for failed test #39189
2016/11/28 14:25:02 Fetching information for failed test #39188
2016/11/28 14:25:02 Fetching information for failed test #39174
2016/11/28 14:25:03 JUnit report successfully written to /Users/Edward/go/src/github.com/rainforestapp/rainforest-cli/example.xml
```