### PR TITLE
[Review] Add self-updating to the client

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -26,3 +26,36 @@ dependencies:
 test:
   override:
     - cd $BUILD && go test -v -race $(glide novendor)
+
+deployment:
+  stable:
+    branch: master
+    tag: /v[0-9]+(\.[0-9]+)*/
+    owner: rainforestapp
+    commands:
+      - cd ~/download && curl -O https://bin.equinox.io/c/mBWdkfai63v/release-tool-stable-linux-amd64.zip
+      - unzip release-tool-stable-linux-amd64.zip -d /usr/local/bin
+      - cd $BUILD && echo $EQUINOX_KEY > ./equinox.key
+      - equinox release --version=${CIRCLE_TAG:1} --platforms="darwin_amd64 linux_amd64 darwin_386 linux_386 windows_amd64 windows_386" --signing-key=equinox.key --app=$EQUINOX_APP_ID --token=$EQUINOX_ACC_TOKEN --channel stable -- -ldflags "-X main.releaseChannel=stable -X main.build=${CIRCLE_SHA1:0:8}" github.com/rainforestapp/rainforest-cli
+      - equinox release --version=${CIRCLE_TAG:1} --platforms="darwin_amd64 linux_amd64 darwin_386 linux_386 windows_amd64 windows_386" --signing-key=equinox.key --app=$EQUINOX_APP_ID --token=$EQUINOX_ACC_TOKEN --channel beta -- -ldflags "-X main.releaseChannel=beta -X main.build=${CIRCLE_SHA1:0:8}" github.com/rainforestapp/rainforest-cli
+      - equinox release --version=${CIRCLE_SHA1:0:8} --platforms="darwin_amd64 linux_amd64" --signing-key=equinox.key --app=$EQUINOX_APP_ID --token=$EQUINOX_ACC_TOKEN --channel dev -- -ldflags "-X main.releaseChannel=dev -X main.build=${CIRCLE_SHA1:0:8}" github.com/rainforestapp/rainforest-cli
+
+
+  beta:
+    tag: /v[0-9]+(\.[0-9]+)*(\-(alpha|beta)\.[0-9]+)?/
+    owner: rainforestapp
+    commands:
+      - cd ~/download && curl -O https://bin.equinox.io/c/mBWdkfai63v/release-tool-stable-linux-amd64.zip
+      - unzip release-tool-stable-linux-amd64.zip -d /usr/local/bin
+      - cd $BUILD && echo $EQUINOX_KEY > ./equinox.key
+      - equinox release --version=${CIRCLE_TAG:1} --platforms="darwin_amd64 linux_amd64 darwin_386 linux_386 windows_amd64 windows_386" --signing-key=equinox.key --app=$EQUINOX_APP_ID --token=$EQUINOX_ACC_TOKEN --channel beta -- -ldflags "-X main.releaseChannel=beta -X main.build=${CIRCLE_SHA1:0:8}" github.com/rainforestapp/rainforest-cli
+      - equinox release --version=${CIRCLE_SHA1:0:8} --platforms="darwin_amd64 linux_amd64" --signing-key=equinox.key --app=$EQUINOX_APP_ID --token=$EQUINOX_ACC_TOKEN --channel dev -- -ldflags "-X main.releaseChannel=dev -X main.build=${CIRCLE_SHA1:0:8}" github.com/rainforestapp/rainforest-cli
+
+  dev:
+    branch: develop
+    owner: rainforestapp
+    commands:
+      - cd ~/download && curl -O https://bin.equinox.io/c/mBWdkfai63v/release-tool-stable-linux-amd64.zip
+      - unzip release-tool-stable-linux-amd64.zip -d /usr/local/bin
+      - cd $BUILD && echo $EQUINOX_KEY > ./equinox.key
+      - equinox release --version=${CIRCLE_SHA1:0:8} --platforms="darwin_amd64 linux_amd64" --signing-key=equinox.key --app=$EQUINOX_APP_ID --token=$EQUINOX_ACC_TOKEN --channel dev -- -ldflags "-X main.releaseChannel=dev -X main.build=${CIRCLE_SHA1:0:8}" github.com/rainforestapp/rainforest-cli

--- a/circle.yml
+++ b/circle.yml
@@ -22,8 +22,6 @@ dependencies:
     - cd $BUILD && glide install
   cache_directories:
     - "~/download"
-  post:
-    - cd $BUILD && rm -f ./equinox.key
 
 test:
   override:
@@ -40,7 +38,6 @@ deployment:
       - equinox release --version=${CIRCLE_TAG:1} --platforms="darwin_amd64 linux_amd64 darwin_386 linux_386 windows_amd64 windows_386" --signing-key=equinox.key --app=$EQUINOX_APP_ID --token=$EQUINOX_ACC_TOKEN --channel stable -- -ldflags "-X main.releaseChannel=stable -X main.build=${CIRCLE_SHA1:0:8}" github.com/rainforestapp/rainforest-cli
       - equinox release --version=${CIRCLE_TAG:1} --platforms="darwin_amd64 linux_amd64 darwin_386 linux_386 windows_amd64 windows_386" --signing-key=equinox.key --app=$EQUINOX_APP_ID --token=$EQUINOX_ACC_TOKEN --channel beta -- -ldflags "-X main.releaseChannel=beta -X main.build=${CIRCLE_SHA1:0:8}" github.com/rainforestapp/rainforest-cli
       - equinox release --version=${CIRCLE_SHA1:0:8} --platforms="darwin_amd64 linux_amd64" --signing-key=equinox.key --app=$EQUINOX_APP_ID --token=$EQUINOX_ACC_TOKEN --channel dev -- -ldflags "-X main.releaseChannel=dev -X main.build=${CIRCLE_SHA1:0:8}" github.com/rainforestapp/rainforest-cli
-
 
   beta:
     tag: /^v[0-9]+(\.[0-9]+)*(\-(alpha|beta)\.[0-9]+)$/
@@ -60,3 +57,6 @@ deployment:
       - unzip release-tool-stable-linux-amd64.zip -d /usr/local/bin
       - cd $BUILD && echo $EQUINOX_KEY > ./equinox.key
       - equinox release --version=${CIRCLE_SHA1:0:8} --platforms="darwin_amd64 linux_amd64" --signing-key=equinox.key --app=$EQUINOX_APP_ID --token=$EQUINOX_ACC_TOKEN --channel dev -- -ldflags "-X main.releaseChannel=dev -X main.build=${CIRCLE_SHA1:0:8}" github.com/rainforestapp/rainforest-cli
+
+  post:
+    - cd $BUILD && rm -f ./equinox.key

--- a/circle.yml
+++ b/circle.yml
@@ -38,6 +38,7 @@ deployment:
       - equinox release --version=${CIRCLE_TAG:1} --platforms="darwin_amd64 linux_amd64 darwin_386 linux_386 windows_amd64 windows_386" --signing-key=equinox.key --app=$EQUINOX_APP_ID --token=$EQUINOX_ACC_TOKEN --channel stable -- -ldflags "-X main.releaseChannel=stable -X main.build=${CIRCLE_SHA1:0:8}" github.com/rainforestapp/rainforest-cli
       - equinox release --version=${CIRCLE_TAG:1} --platforms="darwin_amd64 linux_amd64 darwin_386 linux_386 windows_amd64 windows_386" --signing-key=equinox.key --app=$EQUINOX_APP_ID --token=$EQUINOX_ACC_TOKEN --channel beta -- -ldflags "-X main.releaseChannel=beta -X main.build=${CIRCLE_SHA1:0:8}" github.com/rainforestapp/rainforest-cli
       - equinox release --version=${CIRCLE_SHA1:0:8} --platforms="darwin_amd64 linux_amd64" --signing-key=equinox.key --app=$EQUINOX_APP_ID --token=$EQUINOX_ACC_TOKEN --channel dev -- -ldflags "-X main.releaseChannel=dev -X main.build=${CIRCLE_SHA1:0:8}" github.com/rainforestapp/rainforest-cli
+      - cd $BUILD && rm -f ./equinox.key
 
   beta:
     tag: /^v[0-9]+(\.[0-9]+)*(\-(alpha|beta)\.[0-9]+)$/
@@ -48,6 +49,7 @@ deployment:
       - cd $BUILD && echo $EQUINOX_KEY > ./equinox.key
       - equinox release --version=${CIRCLE_TAG:1} --platforms="darwin_amd64 linux_amd64 darwin_386 linux_386 windows_amd64 windows_386" --signing-key=equinox.key --app=$EQUINOX_APP_ID --token=$EQUINOX_ACC_TOKEN --channel beta -- -ldflags "-X main.releaseChannel=beta -X main.build=${CIRCLE_SHA1:0:8}" github.com/rainforestapp/rainforest-cli
       - equinox release --version=${CIRCLE_SHA1:0:8} --platforms="darwin_amd64 linux_amd64" --signing-key=equinox.key --app=$EQUINOX_APP_ID --token=$EQUINOX_ACC_TOKEN --channel dev -- -ldflags "-X main.releaseChannel=dev -X main.build=${CIRCLE_SHA1:0:8}" github.com/rainforestapp/rainforest-cli
+      - cd $BUILD && rm -f ./equinox.key
 
   dev:
     branch: develop
@@ -57,6 +59,4 @@ deployment:
       - unzip release-tool-stable-linux-amd64.zip -d /usr/local/bin
       - cd $BUILD && echo $EQUINOX_KEY > ./equinox.key
       - equinox release --version=${CIRCLE_SHA1:0:8} --platforms="darwin_amd64 linux_amd64" --signing-key=equinox.key --app=$EQUINOX_APP_ID --token=$EQUINOX_ACC_TOKEN --channel dev -- -ldflags "-X main.releaseChannel=dev -X main.build=${CIRCLE_SHA1:0:8}" github.com/rainforestapp/rainforest-cli
-
-  post:
-    - cd $BUILD && rm -f ./equinox.key
+      - cd $BUILD && rm -f ./equinox.key

--- a/circle.yml
+++ b/circle.yml
@@ -29,8 +29,7 @@ test:
 
 deployment:
   stable:
-    branch: master
-    tag: /v[0-9]+(\.[0-9]+)*/
+    tag: /^v[0-9]+(\.[0-9]+)*$/
     owner: rainforestapp
     commands:
       - cd ~/download && curl -O https://bin.equinox.io/c/mBWdkfai63v/release-tool-stable-linux-amd64.zip
@@ -42,7 +41,7 @@ deployment:
 
 
   beta:
-    tag: /v[0-9]+(\.[0-9]+)*(\-(alpha|beta)\.[0-9]+)?/
+    tag: /^v[0-9]+(\.[0-9]+)*(\-(alpha|beta)\.[0-9]+)$/
     owner: rainforestapp
     commands:
       - cd ~/download && curl -O https://bin.equinox.io/c/mBWdkfai63v/release-tool-stable-linux-amd64.zip

--- a/circle.yml
+++ b/circle.yml
@@ -22,6 +22,8 @@ dependencies:
     - cd $BUILD && glide install
   cache_directories:
     - "~/download"
+  post:
+    - cd $BUILD && rm -f ./equinox.key
 
 test:
   override:

--- a/glide.lock
+++ b/glide.lock
@@ -1,6 +1,14 @@
-hash: 296716a2649407be95c00ead9aa5e0079418f1ad17b9d528c887a10b0e56e14a
-updated: 2016-11-18T15:52:29.565351828-08:00
+hash: 1f8ac5a7cada382b7de1e9309aa622d54fe0b6a14338a178d1133c3078200bcb
+updated: 2016-12-08T13:51:53.945252415Z
 imports:
+- name: github.com/equinox-io/equinox
+  version: 6f97d0d3970881d3e53dd6f547a41109eb055e54
+  subpackages:
+  - internal/go-update
+  - internal/go-update/internal/binarydist
+  - internal/go-update/internal/osext
+  - internal/osext
+  - proto
 - name: github.com/mattn/go-runewidth
   version: d6bea18f789704b5f83375793155289da36a3c7f
 - name: github.com/olekukonko/tablewriter

--- a/glide.yaml
+++ b/glide.yaml
@@ -6,3 +6,4 @@ import:
   version: daf2955e742cf123959884fdff4685aa79b63135
 - package: github.com/urfave/cli
   version: 4205e9c4ee9672a8df5bb4fe486a8aa07e1e4037
+- package: github.com/equinox-io/equinox

--- a/rainforest-cli.go
+++ b/rainforest-cli.go
@@ -13,13 +13,17 @@ import (
 
 const (
 	// Version of the app in SemVer
-	version = "2.0.0"
+	version = "2.0.0-alpha.2"
 )
 
 var (
 	// Build info to be set while building using:
 	// go build -ldflags "-X main.build 'build details'"
 	build string
+
+	// Release channel to be set while building using:
+	// go build -ldflags "-X main.releaseChannel 'channel'"
+	releaseChannel string
 
 	// Rainforest API client
 	api *rainforest.Client
@@ -67,7 +71,11 @@ func (l *logWriter) Write(p []byte) (int, error) {
 func main() {
 	app := cli.NewApp()
 	app.Usage = "Rainforest QA CLI - https://www.rainforestqa.com/"
-	app.Version = version
+	if releaseChannel != "" {
+		app.Version = fmt.Sprintf("%v - %v channel", version, releaseChannel)
+	} else {
+		app.Version = version
+	}
 	// Use our custom writer to print our errors with timestamps
 	cli.ErrWriter = &logWriter{}
 
@@ -343,6 +351,12 @@ func main() {
 			Action: func(c *cli.Context) error {
 				return printBrowsers(c, api)
 			},
+		},
+		{
+			Name:      "update",
+			Usage:     "Updates application to the latest version on specified release channel (stable/beta)",
+			ArgsUsage: "[CHANNEL]",
+			Action:    updateCmd,
 		},
 	}
 

--- a/rainforest-cli.go
+++ b/rainforest-cli.go
@@ -72,11 +72,14 @@ func main() {
 	updateFinishedChan := make(chan struct{})
 	app := cli.NewApp()
 	app.Usage = "Rainforest QA CLI - https://www.rainforestqa.com/"
+	app.Version = version
 	if releaseChannel != "" {
-		app.Version = fmt.Sprintf("%v - %v channel", version, releaseChannel)
-	} else {
-		app.Version = version
+		app.Version = fmt.Sprintf("%v - %v channel", app.Version, releaseChannel)
 	}
+	if build != "" {
+		app.Version = fmt.Sprintf("%v - build: %v", app.Version, build)
+	}
+
 	// Use our custom writer to print our errors with timestamps
 	cli.ErrWriter = &logWriter{}
 

--- a/update.go
+++ b/update.go
@@ -49,13 +49,17 @@ func update(channel string, silent bool) error {
 	}
 
 	// fetch the update and apply it
-	log.Print("Found a cli update, applying it.")
+	if !silent {
+		log.Print("Found a cli update, applying it.")
+	}
 	err = resp.Apply()
 	if err != nil {
 		return err
 	}
 
-	log.Printf("Updated to new version: %s!\n", resp.ReleaseVersion)
+	if !silent {
+		log.Printf("Updated to new version: %s!\n", resp.ReleaseVersion)
+	}
 	return nil
 }
 
@@ -69,4 +73,11 @@ func updateCmd(c cliContext) error {
 		return cli.NewExitError(err.Error(), 1)
 	}
 	return nil
+}
+
+func autoUpdate(c cliContext, updateFinishedChan chan<- struct{}) {
+	if !c.Bool("skip-update") {
+		update("", true)
+	}
+	updateFinishedChan <- struct{}{}
 }

--- a/update.go
+++ b/update.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"log"
+
+	"github.com/equinox-io/equinox"
+	"github.com/urfave/cli"
+)
+
+const equinoxAppID = "app_carcVJmQBRm"
+
+// publicKey is a ECDSA key used to sign the cli binaries
+var publicKey = []byte(`
+-----BEGIN ECDSA PUBLIC KEY-----
+MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEx6zFT0U3/w2adaGXOijiCQtS6KGa+qcj
+HInaiMIY0svw+x9bpoFQhP4FrN9UGxctBh66bUGWcgvKACv4G9vXu4JL54BcTt3E
+KaCtgoR++i4p7H6EPn/A06QYyFCCW4QA
+-----END ECDSA PUBLIC KEY-----
+`)
+
+func update(channel string, silent bool) error {
+	opts := equinox.Options{}
+	if channel == "" && releaseChannel != "" {
+		opts.Channel = releaseChannel
+	} else if channel != "" {
+		opts.Channel = channel
+	} else {
+		// fallback to stable
+		opts.Channel = "stable"
+	}
+
+	if err := opts.SetPublicKeyPEM(publicKey); err != nil {
+		return err
+	}
+
+	// check for the update
+	if !silent {
+		log.Printf("Checking for update on %v channel.", opts.Channel)
+	}
+	resp, err := equinox.Check(equinoxAppID, opts)
+	switch {
+	case err == equinox.NotAvailableErr:
+		if !silent {
+			log.Println("No update available, already at the latest version!")
+		}
+		return nil
+	case err != nil:
+		return err
+	}
+
+	// fetch the update and apply it
+	log.Print("Found a cli update, applying it.")
+	err = resp.Apply()
+	if err != nil {
+		return err
+	}
+
+	log.Printf("Updated to new version: %s!\n", resp.ReleaseVersion)
+	return nil
+}
+
+func updateCmd(c cliContext) error {
+	channel := c.Args().First()
+	if !(channel == "beta" || channel == "stable" || channel == "") {
+		return cli.NewExitError("Invalid release channel - use 'stable' or 'beta'", 1)
+	}
+	err := update(channel, false)
+	if err != nil {
+		return cli.NewExitError(err.Error(), 1)
+	}
+	return nil
+}

--- a/update.go
+++ b/update.go
@@ -12,9 +12,9 @@ const equinoxAppID = "app_carcVJmQBRm"
 // publicKey is a ECDSA key used to sign the cli binaries
 var publicKey = []byte(`
 -----BEGIN ECDSA PUBLIC KEY-----
-MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEx6zFT0U3/w2adaGXOijiCQtS6KGa+qcj
-HInaiMIY0svw+x9bpoFQhP4FrN9UGxctBh66bUGWcgvKACv4G9vXu4JL54BcTt3E
-KaCtgoR++i4p7H6EPn/A06QYyFCCW4QA
+MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEoTjUnZL6bSXdEV9LKD+0zNekogPp8lwf
+8s/auLQXwCHFii7fH8bLwSW+4a9+eF8bWo8FYk4pfSo3WT5DUqGl9qHcnv22MMCK
+eiFH+GffIMk09RFqkcMh5rIPu3ykm5V8
 -----END ECDSA PUBLIC KEY-----
 `)
 


### PR DESCRIPTION
This adds `update` command which can be used to manually trigger updates and switch between channels and auto-updates that are ran async while cli runs.  
I've also set up 3 release channels:
 - `stable` for normal stable releases, that gets pushed from tagged releases in form of `v2.1.3`
 - `beta` for beta releases, gets pushed from tag on any branch in form of `v2.1.3-beta.1`
- `dev` bleeding edge channel, gets pushed after every merge to develop - used to hopefully run RF tests against it.  

All of the needed keys are set as env vars in Circle.