### PR TITLE
Start URI missing fix for v2

### DIFF
--- a/rainforest/tests.go
+++ b/rainforest/tests.go
@@ -44,7 +44,7 @@ type RFTest struct {
 	RFMLID      string                   `json:"rfml_id"`
 	Source      string                   `json:"source"`
 	Title       string                   `json:"title,omitempty"`
-	StartURI    string                   `json:"start_uri,omitempty"`
+	StartURI    string                   `json:"start_uri"`
 	SiteID      int                      `json:"site_id,omitempty"`
 	Description string                   `json:"description,omitempty"`
 	Tags        []string                 `json:"tags,omitempty"`


### PR DESCRIPTION
Go version fix for #244 
Since the zero value for a string is an empty string, this should work fine as the API accepts an empty string for a start URI.