### PR TITLE
Validate for test title presence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Rainforest CLI Changelog
 
+## 1.12.3 - 24th February 2017
+- Validate RFML tests for a title.
+(beb439a3d2c12f618d6b4b00a3a08f1e37bbbe7a, @epaulet)
+
 ## 1.12.2 - 23rd February 2017
 - Default `start_uri` attribute to "/" if omitted from RFML test.
 (ec6049407ec635b7f7bc4f8da516ccddad2b78b3, @epaulet)

--- a/lib/rainforest_cli/test_parser.rb
+++ b/lib/rainforest_cli/test_parser.rb
@@ -5,9 +5,12 @@ module RainforestCli::TestParser
   require 'rainforest_cli/test_parser/step'
   require 'rainforest_cli/test_parser/embedded_test'
 
-  class Error < Struct.new(:line, :reason)
+  class Error < Struct.new(:location, :reason)
     def to_s
-      "Line #{line}: #{reason}"
+      case location
+      when Integer then "Line #{location}: #{reason}"
+      when Symbol, String then "Field #{location}: #{reason}"
+      end
     end
   end
 
@@ -98,7 +101,14 @@ module RainforestCli::TestParser
       end
 
       if @test.rfml_id == nil
-        @test.errors[0] = Error.new(0, 'Missing RFML ID. Please start a line #! followed by a unique id.')
+        @test.errors[:rfml_id] = Error.new(:rfml_id, 'Missing RFML ID. Please start a line #! followed by a unique id.')
+      end
+
+      if @test.title.nil? || @test.title.empty?
+        @test.errors[:title] = Error.new(
+          :title,
+          'Missing Title for test. Please start a line with "# title: " and specify your test title.',
+        )
       end
 
       return @test

--- a/lib/rainforest_cli/version.rb
+++ b/lib/rainforest_cli/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module RainforestCli
-  VERSION = '1.12.2'
+  VERSION = '1.12.3'
 end

--- a/spec/rainforest_cli/test_parser_spec.rb
+++ b/spec/rainforest_cli/test_parser_spec.rb
@@ -12,8 +12,7 @@ describe RainforestCli::TestParser do
     end
 
     describe '#process' do
-      let(:parsed_test) { subject.process }
-      let(:parsed_step) { parsed_test.steps.first }
+      let(:parsed_test) { described_class.new(file_name).process }
 
       describe 'parsing comments' do
         it 'properly identifies comments' do
@@ -28,7 +27,18 @@ describe RainforestCli::TestParser do
         end
 
         it 'properly parses step metadata' do
+          parsed_step = parsed_test.steps.first
           expect(parsed_step.redirect).to eq('false')
+        end
+      end
+
+      describe 'errors' do
+        context 'no title' do
+          let(:file_name) { './spec/validation-examples/parse_errors/no_title.rfml' }
+
+          specify do
+            expect(parsed_test.errors[:title]).to_not be_nil
+          end
         end
       end
     end

--- a/spec/validation-examples/parse_errors/no_question.rfml
+++ b/spec/validation-examples/parse_errors/no_question.rfml
@@ -2,4 +2,4 @@
 # title: No Question Test
 # start_uri: /
 
-This is an action without a question.
+This is an action without a question?

--- a/spec/validation-examples/parse_errors/no_rfml_id.rfml
+++ b/spec/validation-examples/parse_errors/no_rfml_id.rfml
@@ -2,4 +2,4 @@
 # start_uri: /
 
 This is an action.
-This is a question.
+This is a question?

--- a/spec/validation-examples/parse_errors/no_title.rfml
+++ b/spec/validation-examples/parse_errors/no_title.rfml
@@ -1,0 +1,6 @@
+#! example_test
+# start_uri: /
+# This test has no title
+
+This is a step action.
+This is a question?


### PR DESCRIPTION
Title is a required field, but we haven't been validating for it.

Example output:
```
$ bin/rainforest validate --test-folder spec/validation-examples/parse_errors/
I, [2017-03-02T09:10:02.328909 #56181]  INFO -- : Validating parsing errors...
E, [2017-03-02T09:10:02.329023 #56181] ERROR -- : Parsing errors:
E, [2017-03-02T09:10:02.329048 #56181] ERROR -- :
E, [2017-03-02T09:10:02.329068 #56181] ERROR -- : 	rainforest-cli/spec/validation-examples/parse_errors/no_question_mark.rfml
E, [2017-03-02T09:10:02.329094 #56181] ERROR -- : 	Line 5: Missing ?
E, [2017-03-02T09:10:02.329160 #56181] ERROR -- : 	rainforest-cli/spec/validation-examples/parse_errors/no_rfml_id.rfml
E, [2017-03-02T09:10:02.329232 #56181] ERROR -- : 	Field rfml_id: Missing RFML ID. Please start a line #! followed by a unique id.
E, [2017-03-02T09:10:02.329276 #56181] ERROR -- : 	rainforest-cli/spec/validation-examples/parse_errors/no_title.rfml
E, [2017-03-02T09:10:02.329320 #56181] ERROR -- : 	Field title: Missing Title for test. Please start a line with "# title: " and specify your test title.
E, [2017-03-02T09:10:02.329352 #56181] ERROR -- :
I, [2017-03-02T09:10:02.329388 #56181]  INFO -- : Validating embedded test IDs...
I, [2017-03-02T09:10:02.329499 #56181]  INFO -- : No API Token set. Using local tests only...
I, [2017-03-02T09:10:02.329625 #56181]  INFO -- :
I, [2017-03-02T09:10:02.329700 #56181]  INFO -- : [INVALID] - Please see log to correct errors.
```