### PR TITLE
Parse site id on export (v1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Rainforest CLI Changelog
 
+## 1.12.5 - 7th March 2017
+- Include site ID for exported tests.
+(1816af9406013ac7594765822f73066adf332cf1, @epaulet)
+
 ## 1.12.4 - 4th March 2017
 - Lower threads used in HTTP requests to 4 for more stability.
 (ce01a1defa8b9a5e523af0bc5797a5eef365e4e1, @epaulet)

--- a/lib/rainforest_cli/exporter.rb
+++ b/lib/rainforest_cli/exporter.rb
@@ -81,16 +81,19 @@ class RainforestCli::Exporter
   end
 
   def get_header(test)
-    browsers = test['browsers'].map { |b| b['name'] if b['state'] == 'enabled' }.compact
-    <<-EOF
+    header = <<-EOF
 #! #{test['rfml_id']}
 # title: #{test['title']}
 # start_uri: #{test['start_uri']}
-# tags: #{test['tags'].join(", ")}
-# browsers: #{browsers.join(", ")}
-#
-
+# site_id: #{test['site_id']}
     EOF
+
+    header += "# tags: #{test['tags'].join(', ')}\n" if test['tags'].any?
+
+    browsers = test['browsers'].map { |b| b['name'] if b['state'] == 'enabled' }.compact
+    header += "# browsers: #{browsers.join(', ')}\n" if browsers.any?
+    header += "\n"
+    header
   end
 
   def http_client

--- a/lib/rainforest_cli/version.rb
+++ b/lib/rainforest_cli/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module RainforestCli
-  VERSION = '1.12.4'
+  VERSION = '1.12.5'
 end

--- a/spec/rainforest_cli/exporter_spec.rb
+++ b/spec/rainforest_cli/exporter_spec.rb
@@ -80,11 +80,13 @@ describe RainforestCli::Exporter do
       ]
     end
     let(:single_test_id) { 123 }
+    let(:single_test_site_id) { 987 }
     let(:single_test) do
       {
         'id' => single_test_id,
         'title' => 'Test title',
         'start_uri' => '/uri',
+        'site_id' => single_test_site_id,
         'tags' => ['foo', 'bar'],
         'browsers' => [
           { 'name' => 'chrome', 'state' => 'enabled' },
@@ -121,12 +123,18 @@ describe RainforestCli::Exporter do
       expect(file).to_not include("- #{embedded_rfml_id}")
     end
 
-    it 'print enabled browsers only' do
+    it 'prints enabled browsers only' do
       subject.export
-      comments = file[0]
-      expect(comments).to include('chrome')
-      expect(comments).to include('safari')
-      expect(comments).to_not include('firefox')
+      meta_data = file[0]
+      expect(meta_data).to include('chrome')
+      expect(meta_data).to include('safari')
+      expect(meta_data).to_not include('firefox')
+    end
+
+    it 'prints site id' do
+      subject.export
+      meta_data = file[0]
+      expect(meta_data).to include("# site_id: #{single_test_site_id}")
     end
 
     context 'action and/or question contain newlines' do


### PR DESCRIPTION
 Self explanatory. The export command does not parse the test's site id.