### PR TITLE
Replace more illegal filename characters with underscore

### DIFF
--- a/rfml.go
+++ b/rfml.go
@@ -654,9 +654,20 @@ func prepareTestDirectory(testDir string) (string, error) {
 	return absTestDirectory, nil
 }
 
+var illegalFilenameStrs = []string{"\\", "/", ":", "<", ">", "\"", "|", "?", "*", " "}
+
 func sanitizeTestTitle(title string) string {
 	title = strings.TrimSpace(title)
-	return strings.Replace(title, string(filepath.Separator), "_", -1)
+	title = strings.ToLower(title)
+
+	replacerList := make([]string, len(illegalFilenameStrs)*2)
+	for idx, illegalStr := range illegalFilenameStrs {
+		replacerList[idx*2] = illegalStr
+		replacerList[idx*2+1] = "_"
+	}
+
+	r := strings.NewReplacer(replacerList...)
+	return r.Replace(title)
 }
 
 func testCreationWorker(api *rainforest.Client,

--- a/rfml_test.go
+++ b/rfml_test.go
@@ -287,13 +287,19 @@ func TestDownloadRFML(t *testing.T) {
 	}
 
 	paddedTestID := fmt.Sprintf("%010d", testID)
-	sanitizedTitle := strings.TrimSpace(title)
+	sanitizedTitle := "my_test_title"
 	expectedFileName := fmt.Sprintf("%v_%v.rfml", paddedTestID, sanitizedTitle)
 	expectedRFMLPath := filepath.Join(testDefaultSpecFolder, expectedFileName)
 
-	_, err = os.Stat(expectedRFMLPath)
+	fileInfo, err := os.Stat(expectedRFMLPath)
 	if os.IsNotExist(err) {
 		t.Fatalf("Expected RFML test does not exist: %v", expectedRFMLPath)
+	}
+
+	if fileInfo.Name() != expectedFileName {
+		t.Errorf("Expected RFML file path %v, got %v", expectedRFMLPath, fileInfo.Name())
+	} else if err != nil {
+		t.Fatalf(err.Error())
 	}
 
 	var contents []byte
@@ -310,5 +316,15 @@ func TestDownloadRFML(t *testing.T) {
 
 	if !strings.Contains(rfmlText, rfmlID) {
 		t.Errorf("Expected RFML ID \"%v\" to appear in RFML test", rfmlID)
+	}
+}
+
+func TestSanitizeTestTitle(t *testing.T) {
+	illegalTitle := "Foo\\foo/\\foo:foo <foo>foo\"Foo|fOO?foo|*foo foo "
+	sanitizedTitle := sanitizeTestTitle(illegalTitle)
+	expectedSanitizedTitle := "foo_foo__foo_foo__foo_foo_foo_foo_foo__foo_foo"
+
+	if sanitizedTitle != expectedSanitizedTitle {
+		t.Errorf("Expected sanitized title to be %v, got %v", expectedSanitizedTitle, sanitizedTitle)
 	}
 }


### PR DESCRIPTION
Replace characters that are reserved in Linux/Windows operating systems with an underscore and lowercase all test titles.