### PR TITLE
Empty browsers and tags attributes fix

### DIFF
--- a/rainforest/rfml.go
+++ b/rainforest/rfml.go
@@ -91,6 +91,12 @@ func (r *RFMLReader) ReadAll() (*RFTest, error) {
 					}
 					parsedRFTest.SiteID = siteID
 				case "tags":
+					// If you split the empty string instead, you will get: []string{""}
+					if len(value) == 0 {
+						parsedRFTest.Tags = []string{}
+						continue
+					}
+
 					splitTags := strings.Split(value, ",")
 					strippedTags := make([]string, len(splitTags))
 					for i, tag := range splitTags {
@@ -98,6 +104,12 @@ func (r *RFMLReader) ReadAll() (*RFTest, error) {
 					}
 					parsedRFTest.Tags = strippedTags
 				case "browsers":
+					// If you split the empty string instead, you will get: []string{""}
+					if len(value) == 0 {
+						parsedRFTest.Browsers = []string{}
+						continue
+					}
+
 					splitBrowsers := strings.Split(value, ",")
 					strippedBrowsers := make([]string, len(splitBrowsers))
 					for i, tag := range splitBrowsers {

--- a/rainforest/rfml_test.go
+++ b/rainforest/rfml_test.go
@@ -176,6 +176,37 @@ func TestReadAll(t *testing.T) {
 	} else if !strings.Contains(err.Error(), "# title") {
 		t.Errorf("Wrong error reported. Expected error for title field. Returned error: %v", err.Error())
 	}
+
+	// Empty browser and tag list
+	testText = fmt.Sprintf(`#! %v
+# title: %v
+# start_uri: %v
+# browsers:
+# tags:
+
+%v
+%v`,
+		validTestValues.RFMLID,
+		validTestValues.Title,
+		validTestValues.StartURI,
+		validSteps[0].(RFTestStep).Action,
+		validSteps[0].(RFTestStep).Response,
+	)
+
+	r = strings.NewReader(testText)
+	reader = NewRFMLReader(r)
+	rfTest, err = reader.ReadAll()
+	if err != nil {
+		t.Fatalf("Unexpected error from ReadAll: %v", err.Error())
+	}
+
+	if browserCount := len(rfTest.Browsers); browserCount != 0 {
+		t.Fatalf("Unexpected browsers, expected 0, got %v: %v", browserCount, rfTest.Browsers)
+	}
+
+	if tagCount := len(rfTest.Tags); tagCount != 0 {
+		t.Fatalf("Unexpected tags, expected 0, got %v: %v", tagCount, rfTest.Tags)
+	}
 }
 
 func TestWriteRFMLTest(t *testing.T) {

--- a/rainforest/tests.go
+++ b/rainforest/tests.go
@@ -47,8 +47,8 @@ type RFTest struct {
 	StartURI    string                   `json:"start_uri"`
 	SiteID      int                      `json:"site_id,omitempty"`
 	Description string                   `json:"description,omitempty"`
-	Tags        []string                 `json:"tags,omitempty"`
-	BrowsersMap []map[string]interface{} `json:"browsers,omitempty"`
+	Tags        []string                 `json:"tags"`
+	BrowsersMap []map[string]interface{} `json:"browsers"`
 	Elements    []testElement            `json:"elements,omitempty"`
 
 	// Browsers and Steps are helper fields
@@ -75,10 +75,6 @@ type testElementDetails struct {
 
 // mapBrowsers fills the browsers field with format recognized by the API
 func (t *RFTest) mapBrowsers() {
-	// if there are no browsers skip mapping
-	if len(t.Browsers) == 0 {
-		return
-	}
 	t.BrowsersMap = make([]map[string]interface{}, len(t.Browsers))
 	for i, browser := range t.Browsers {
 		mappedBrowser := map[string]interface{}{
@@ -91,11 +87,7 @@ func (t *RFTest) mapBrowsers() {
 
 // unmapBrowsers parses browsers from the API format to internal go one
 func (t *RFTest) unmapBrowsers() {
-	// if there are no browsers skip unmapping
-	if len(t.BrowsersMap) == 0 {
-		return
-	}
-
+	t.Browsers = []string{}
 	for _, browserMap := range t.BrowsersMap {
 		if browserMap["state"] == "enabled" {
 			t.Browsers = append(t.Browsers, browserMap["name"].(string))
@@ -161,6 +153,12 @@ func (t *RFTest) PrepareToUploadFromRFML(mappings TestIDMappings) error {
 	if t.StartURI == "" {
 		t.StartURI = "/"
 	}
+
+	// prevent []string(nil) as a value for Tags
+	if len(t.Tags) == 0 {
+		t.Tags = []string{}
+	}
+
 	t.mapBrowsers()
 	err := t.marshallElements(mappings)
 	if err != nil {


### PR DESCRIPTION
If you leave
`# browsers:`

blank, you will get the following error:
"You have selected at least one unauthorized browers."

Because the CLI will send the following attribute to the server
`{ "browsers": [""] }`

This PR should fix that (and a similar issue for tags), but not omitting the `browsers` or `tag` attributes in the body of the request, and instead sends an empty array if the browser/tag list is empty or omitted.