### PR TITLE
Upload files anyway if embedded files do not exist

### DIFF
--- a/rainforest/rfml.go
+++ b/rainforest/rfml.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"log"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -339,7 +340,11 @@ func (c *Client) ParseEmbeddedFiles(test *RFTest) error {
 
 			var file *os.File
 			file, err = os.Open(filePath)
-			if err != nil {
+
+			if os.IsNotExist(err) {
+				log.Printf("Error for test: %v\n\tNo such file exists: %v\n", test.RFMLPath, filePath)
+				continue
+			} else if err != nil {
 				return "", err
 			}
 


### PR DESCRIPTION
This is the behavior that existed in 1.X:
https://github.com/rainforestapp/rainforest-cli/blob/version-1/lib/rainforest_cli/uploader/uploadable_parser.rb#L39