### PR TITLE
RF-2789 Return false exit status for unknown flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,45 +1,45 @@
 # Rainforest CLI Changelog
 
-## 2.3.0 - 1 Sep 2017
-- Fix bug that parsed a remote file reference as a file path when using
-file.screenshot and file.download step variables.
-(6a443d7e0ef5cc1ce9696ee07552ed87611e450b, @epaulet)
+## 2.4.0 - 2017-09-03
+- Exit with non-zero status if an unknown flag is given
+  - (2ebdd906d8e4314b3c0db4d0a72a2d6ca2af52ee, @jbarber)
+
+## 2.3.0 - 2017-09-01
+- Fix bug that parsed a remote file reference as a file path when using file.screenshot and file.download step variables.
+  - (6a443d7e0ef5cc1ce9696ee07552ed87611e450b, @epaulet)
 - Add new prerelease feature for running local RFML tests.
-(573fdb7f179aa12baf99a4b2bf351649633d1636, @shosti)
+  - (573fdb7f179aa12baf99a4b2bf351649633d1636, @shosti)
 
-## 2.2.0 - 14 Jul 2017
-- Added a `--debug` flag to print out http headers.
-(a9bc9dde31124f1f37934c8e85c4bd11692a8f9c, @sondhayni-rfqa)
+## 2.2.0 - 2017-07-14
+- Added a `--debug` flag to print out HTTP headers.
+  - (a9bc9dde31124f1f37934c8e85c4bd11692a8f9c, @sondhayni-rfqa)
 
-## 2.1.1 - 22 Jun 2017
+## 2.1.1 - 2017-06-22
 - Changed default file name when downloading RFML tests:
   - Do not use sequences of multiple underscores in file name.
-  (12f2dafa9cd62d489c4837055535fb45580b9ef8, @epaulet)
+    - (12f2dafa9cd62d489c4837055535fb45580b9ef8, @epaulet)
   - Do not use more than 30 characters from a test's title in file name.
-  (c2f1baeafff3f89eff3f32295f301f9be6211dda, @epaulet)
+    - (c2f1baeafff3f89eff3f32295f301f9be6211dda, @epaulet)
 
-## 2.1.0 - 19 Jun 2017
+## 2.1.0 - 2017-06-19
 - Added run group support for future run group feature.
-(86a4573db19cb2b5aef7a53c765d0121be60520f, @sondhayni-rfqa)
-(21e9fda469a23f40a9b208e8660b4b2b80d00c86, @epaulet)
-- Replace all non-alphanumeric characters with underscores when creating RFML
-files. (21e9fda469a23f40a9b208e8660b4b2b80d00c86, @epaulet)
+  - (86a4573db19cb2b5aef7a53c765d0121be60520f, @sondhayni-rfqa)
+  - (21e9fda469a23f40a9b208e8660b4b2b80d00c86, @epaulet)
+- Replace all non-alphanumeric characters with underscores when creating RFML files.
+  - (21e9fda469a23f40a9b208e8660b4b2b80d00c86, @epaulet)
 
-## 2.0.4 - 5 Jun 2017
-- Log errors when attempting to upload tests with embedded files that do not
-exist locally, but upload the test anyway. This behavior is backwards compatible
-with versions 1.X.
-(52cf356f6d4a1d4359537e53923949facd5d5c08, @epaulet)
+## 2.0.4 - 2017--06-05
+- Log errors when attempting to upload tests with embedded files that do not exist locally, but upload the test anyway. This behavior is backwards compatible with versions 1.X.
+  - (52cf356f6d4a1d4359537e53923949facd5d5c08, @epaulet)
 
-## 2.0.3 - 2 Jun 2017
-- You may now either omit the browsers attribute or leave the browser list
-empty to set the default browsers for a test as none.
-(49d48abf5b6c3591f6998622a34884426d9526a1, @epaulet)
+## 2.0.3 - 2017-06-02
+- You may now either omit the browsers attribute or leave the browser list empty to set the default browsers for a test as none.
+  - (49d48abf5b6c3591f6998622a34884426d9526a1, @epaulet)
 
-## 2.0.2 - 2nd May 2017
+## 2.0.2 - 2017-05-02
 - Replace illegal file path characters when creating RFML files.
-(175c98e6568a909cd9a000a8381768d7189aa25a, @epaulet)
+  - (175c98e6568a909cd9a000a8381768d7189aa25a, @epaulet)
 
-## 2.0.1 - 12th Apr 2017
+## 2.0.1 - 2017-04-12
 - Download all tests from test API and return proper errors.
-(726f2de5215d66eeb76aa530f76b4a8a59e76f71, @epaulet)
+  - (726f2de5215d66eeb76aa530f76b4a8a59e76f71, @epaulet)

--- a/README.md
+++ b/README.md
@@ -288,3 +288,30 @@ Email [help@rainforestqa.com](mailto:help@rainforestqa.com) if you're having tro
 4. Commit your changes (`git commit -am 'Add some feature'`)
 5. Push to the branch (`git push origin my-new-feature`)
 6. Create new Pull Request
+
+## Release process
+
+Check the `circle.yml` for the latest, but currently merging to master will build and deploy to the following Equinox channels:
+
+Tag                             | Channels
+--------------------------------|-------------
+No tag                          | dev
+vX.Y.Z-alpha.N or vX.Y.Z-beta.N | beta, dev
+vX.Y.Z                          | stable, beta, dev
+
+Development + release process is:
+
+1. Branch from master
+2. Do work
+3. Open PR against master
+4. Merge to master
+5. Branch from master to update `CHANGELOG.md` to include the commit hashes and release date
+6. Update the `version` constant in `rainforest-cli.go` following [semvar](http://semver.org/)
+7. Merge to master
+8. Tag the master branch with the release:
+```bash
+   git tag vX.Y.Z or vX.Y.Z-alpha.N or vX.Y.Z-beta.N
+   git push origin vX.Y.Z
+```
+9. Merge to master to release to stable/beta/dev
+10. Add release to Github [release page](https://github.com/rainforestapp/rainforest-cli/releases)

--- a/rainforest-cli.go
+++ b/rainforest-cli.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	// Version of the app in SemVer
-	version = "2.3.0"
+	version = "2.4.0"
 	// This is the default spec folder for RFML tests
 	defaultSpecFolder = "./spec/rainforest"
 )
@@ -118,6 +118,9 @@ func main() {
 			Name:  "debug",
 			Usage: "Output http request header information for debug purposes",
 		},
+	}
+	app.OnUsageError = func(c *cli.Context, err error, isSubcommand bool) error {
+		return cli.NewExitError("Unknown argument", 1)
 	}
 
 	app.Commands = []cli.Command{


### PR DESCRIPTION
So that giving bad flags doesn't appear the same as having a passing
test suite

https://rainforest.atlassian.net/browse/RF-2789

No idea how to test this?

```
$ ./rainforest-cli --foo
2017/08/26 00:19:29 Unknown argument
```