### PR TITLE
RF-3170 Ignore already uploaded files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Rainforest CLI Changelog
 
+## WIP
+- Fix bug that parsed a remote file reference as a file path when using
+file.screenshot and file.download step variables.
+
 ## 2.2.0 - 14 Jul 2017
 - Added a `--debug` flag to print out http headers.
 (a9bc9dde31124f1f37934c8e85c4bd11692a8f9c, @sondhayni-rfqa)
@@ -36,4 +40,3 @@ empty to set the default browsers for a test as none.
 ## 2.0.1 - 12th Apr 2017
 - Download all tests from test API and return proper errors.
 (726f2de5215d66eeb76aa530f76b4a8a59e76f71, @epaulet)
-

--- a/rainforest/tests_test.go
+++ b/rainforest/tests_test.go
@@ -219,6 +219,42 @@ func TestHasUploadableFiles(t *testing.T) {
 		t.Error("Test has uploadable files")
 	}
 
+	// Remote file download reference
+	test.Steps = []interface{}{
+		RFTestStep{
+			Action:   "{{ file.download(1235, foobar, testing.csv) }}",
+			Response: "nothing",
+		},
+	}
+
+	if test.HasUploadableFiles() {
+		t.Error("Test only has remote uploadable files")
+	}
+
+	// Remote screenshot reference
+	test.Steps = []interface{}{
+		RFTestStep{
+			Action:   "{{ file.screenshot(3332, hkBde5) }}",
+			Response: "nothing",
+		},
+	}
+
+	if test.HasUploadableFiles() {
+		t.Error("Test only has remote uploadable files")
+	}
+
+	// Remote and local reference
+	test.Steps = []interface{}{
+		RFTestStep{
+			Action:   "{{ file.download(1235, foobar, testing.csv) }} {{ file.download(./local/path.csv) }}",
+			Response: "nothing",
+		},
+	}
+
+	if !test.HasUploadableFiles() {
+		t.Error("Test should have an uploadable file")
+	}
+
 	// With missing argument
 	test.Steps = []interface{}{
 		RFTestStep{


### PR DESCRIPTION
This just ignores remote file references for already uploaded files, eg `{{ file.screenshot(1234, h4sD5k) }}` as they can be left as is for uploading.