### PR TITLE
RF-2852 Backoff if the API returns an error

### DIFF
--- a/runner.go
+++ b/runner.go
@@ -202,7 +202,7 @@ func filterExecuteTests(tests []*rainforest.RFTest, tags []string, forceExecute,
 }
 
 func monitorRunStatus(c cliContext, runID int) error {
-	backoff := 1
+	failed_attempts := 1
 
 	for {
 		status, msg, done, err := getRunStatus(c.Bool("fail-fast"), runID)
@@ -223,20 +223,19 @@ func monitorRunStatus(c cliContext, runID int) error {
 		}
 
 		// If we've had too many errors, give up
-		if backoff >= 5 {
-			msg := fmt.Sprintf("Can not get run status after %d attempts, giving up", backoff)
+		if failed_attempts >= 5 {
+			msg := fmt.Sprintf("Can not get run status after %d attempts, giving up", failed_attempts)
 			return cli.NewExitError(msg, 1)
 		}
 
-		// If we hit an error, wait longer before retrying
+		// If we hit an error, record it
 		if err != nil {
-			backoff++
+			failed_attempts++
 		} else {
-			// Reset backoff
-			backoff = 1
+			// Reset attempts
+			failed_attempts = 1
 		}
 
-		log.Printf("Waiting for %s before retrying", runStatusPollInterval)
 		time.Sleep(runStatusPollInterval)
 	}
 }

--- a/runner_test.go
+++ b/runner_test.go
@@ -262,3 +262,36 @@ func TestStartLocalRun(t *testing.T) {
 		}
 	}
 }
+
+func TestPow(t *testing.T) {
+	testCases := [][]int{
+		[]int{-2, 2, 4},
+		[]int{0, 1, 0},
+		[]int{1, 1, 1},
+		[]int{1, 2, 1},
+		[]int{2, 1, 2},
+		[]int{2, 2, 4},
+		[]int{2, 0, 1},
+		[]int{0, 0, 1},
+	}
+
+	for _, testCase := range testCases {
+		if testCase[2] != Pow(testCase[0], testCase[1]) {
+			t.Errorf("Pow(%v, %v) != %v", testCase[0], testCase[1], testCase[2])
+		}
+	}
+}
+
+func TestPowPanic(t *testing.T) {
+	recovered := false
+	defer func() {
+		if r := recover(); r != nil {
+			recovered = true
+		}
+	}()
+
+	Pow(2, -2)
+	if recovered != false {
+		t.Errorf("Pow() should panic on negative exponent")
+	}
+}

--- a/runner_test.go
+++ b/runner_test.go
@@ -262,36 +262,3 @@ func TestStartLocalRun(t *testing.T) {
 		}
 	}
 }
-
-func TestPow(t *testing.T) {
-	testCases := [][]int{
-		[]int{-2, 2, 4},
-		[]int{0, 1, 0},
-		[]int{1, 1, 1},
-		[]int{1, 2, 1},
-		[]int{2, 1, 2},
-		[]int{2, 2, 4},
-		[]int{2, 0, 1},
-		[]int{0, 0, 1},
-	}
-
-	for _, testCase := range testCases {
-		if testCase[2] != Pow(testCase[0], testCase[1]) {
-			t.Errorf("Pow(%v, %v) != %v", testCase[0], testCase[1], testCase[2])
-		}
-	}
-}
-
-func TestPowPanic(t *testing.T) {
-	recovered := false
-	defer func() {
-		if r := recover(); r != nil {
-			recovered = true
-		}
-	}()
-
-	Pow(2, -2)
-	if recovered != false {
-		t.Errorf("Pow() should panic on negative exponent")
-	}
-}


### PR DESCRIPTION
When waiting for a run to complete, instead of failing if we get an API
error, backoff and retry upto 5 times.