### PR TITLE
Add file path to validation errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Rainforest CLI Changelog
 
+## 2.8.1 - 2017-10-10
+- Add file path to invalid file error message when using the `validate` command.
+  - (be557fff7e39c478426f3ecd6289fe5689c7a83f, @epaulet)
+
 ## 2.8.0 - 2017-10-03
 - Add `feature_id` and `state` fields to RFML headers.
   - (7e6b0b87e438838cef7b28fda4396f739f819c33, @epaulet)

--- a/rainforest-cli.go
+++ b/rainforest-cli.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	// Version of the app in SemVer
-	version = "2.8.0"
+	version = "2.8.1"
 	// This is the default spec folder for RFML tests
 	defaultSpecFolder = "./spec/rainforest"
 )

--- a/rfml.go
+++ b/rfml.go
@@ -23,7 +23,7 @@ type fileParseError struct {
 }
 
 func (e fileParseError) Error() string {
-	return fmt.Sprintf("%v:%v", e.filePath, e.parseError.Error())
+	return fmt.Sprintf("%v: %v", e.filePath, e.parseError.Error())
 }
 
 // validateRFML is a wrapper around two other validation functions
@@ -123,7 +123,7 @@ func readRFMLFile(filePath string) (*rainforest.RFTest, error) {
 	var pTest *rainforest.RFTest
 	pTest, err = rfmlReader.ReadAll()
 	if err != nil {
-		return nil, err
+		return nil, fileParseError{filePath, err}
 	}
 
 	pTest.RFMLPath = filePath
@@ -318,6 +318,10 @@ func deleteRFML(c cliContext) error {
 	}
 	rfmlReader := rainforest.NewRFMLReader(f)
 	parsedRFML, err := rfmlReader.ReadAll()
+	if err != nil {
+		return fileParseError{filePath, err}
+	}
+
 	if parsedRFML.RFMLID == "" {
 		return cli.NewExitError("RFML file doesn't have RFML ID", 1)
 	}

--- a/rfml_test.go
+++ b/rfml_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 
 	"github.com/rainforestapp/rainforest-cli/rainforest"
+	"github.com/urfave/cli"
 )
 
 func TestNewRFMLTest(t *testing.T) {
@@ -396,6 +397,39 @@ func TestUploadRFML(t *testing.T) {
 	}
 }
 
+func TestDeleteRFML(t *testing.T) {
+	// Test error in parsing file
+	dir, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	defer os.RemoveAll(dir)
+
+	rfmlFilePath := filepath.Join(dir, "testing.rfml")
+	fileContents := `#! testing
+# title: hello
+# site_id: a_string
+`
+	err = ioutil.WriteFile(rfmlFilePath, []byte(fileContents), 0666)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	dummyMappings := map[string]interface{}{}
+	args := cli.Args{rfmlFilePath}
+	ctx := newFakeContext(dummyMappings, args)
+
+	err = deleteRFML(ctx)
+	if err == nil {
+		t.Fatal("Expected parse error but received no error.")
+	}
+
+	errMsg := err.Error()
+	if !strings.Contains(errMsg, rfmlFilePath) {
+		t.Errorf("Expected error to contain file path \"%v\". Got:\n%v", rfmlFilePath, errMsg)
+	}
+}
+
 func TestDownloadRFML(t *testing.T) {
 	context := new(fakeContext)
 	testAPI := new(testRfmlAPI)
@@ -647,6 +681,35 @@ func TestReadRFMLFiles(t *testing.T) {
 		if !reflect.DeepEqual(wantFiles, gotFiles) {
 			t.Errorf("Unexpected files returned (want: %v, got: %v)", wantFiles, gotFiles)
 		}
+	}
+}
+
+func TestReadRFMLFile(t *testing.T) {
+	// Test error in parsing file
+	dir, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	defer os.RemoveAll(dir)
+
+	rfmlFilePath := filepath.Join(dir, "testing.rfml")
+	fileContents := `#! testing
+# title: hello
+# site_id: a_string
+`
+	err = ioutil.WriteFile(rfmlFilePath, []byte(fileContents), 0666)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	_, err = readRFMLFile(rfmlFilePath)
+	if err == nil {
+		t.Fatal("Expected parse error but received no error.")
+	}
+
+	errMsg := err.Error()
+	if !strings.Contains(errMsg, rfmlFilePath) {
+		t.Errorf("Expected error to contain file path \"%v\". Got:\n%v", rfmlFilePath, errMsg)
 	}
 }
 


### PR DESCRIPTION
We were forgetting to wrap the errors properly in a couple of instances.

The error output has the file path in it for validations:
```
$ ./testing --skip-update validate
2017/10/06 13:44:38 spec/rainforest/0000097596_testing_the_cli.rfml: RFML parsing error in line 11: Each step must contain a question, with a `?`
```