### PR TITLE
Add default JUnit report name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Rainforest CLI Changelog
 
+## 2.8.2 - WIP
+- Add a default JUnit test suite name for runs without a description.
+
 ## 2.8.1 - 2017-10-10
 - Add file path to invalid file error message when using the `validate` command.
   - (be557fff7e39c478426f3ecd6289fe5689c7a83f, @epaulet)

--- a/rainforest-cli_test.go
+++ b/rainforest-cli_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"reflect"
 	"testing"
 
@@ -49,6 +50,8 @@ func TestShuffleFlags(t *testing.T) {
 		}
 	}
 }
+
+var errStub = errors.New("STUB")
 
 // fakeContext is a helper for testing the cli interfacing functions
 type fakeContext struct {

--- a/reporter.go
+++ b/reporter.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/xml"
+	"fmt"
 	"log"
 	"os"
 	"path/filepath"
@@ -235,12 +236,17 @@ func createJUnitReportSchema(runDetails *rainforest.RunDetails, api reporterAPI)
 	finalStateName := runDetails.StateDetails.Name
 	runDuration := runDetails.Timestamps[finalStateName].Sub(runDetails.Timestamps["created_at"]).Seconds()
 	report := &jUnitReportSchema{
-		Name:      runDetails.Description,
 		Errors:    runDetails.TotalNoResultTests,
 		Failures:  runDetails.TotalFailedTests,
 		Tests:     runDetails.TotalTests,
 		TestCases: testCases,
 		Time:      runDuration,
+	}
+
+	if runDesc := runDetails.Description; runDesc != "" {
+		report.Name = runDesc
+	} else {
+		report.Name = fmt.Sprintf("Run #%v", runDetails.ID)
 	}
 
 	return report, nil

--- a/reporter.go
+++ b/reporter.go
@@ -23,11 +23,10 @@ type reporterAPI interface {
 }
 
 type reporter struct {
-	getRunDetails               func(int, reporterAPI) (*rainforest.RunDetails, error)
-	createOutputFile            func(string) (*os.File, error)
-	createJUnitReportSchema     func(*rainforest.RunDetails, reporterAPI) (*jUnitReportSchema, error)
-	createJunitTestReportSchema func(int, []rainforest.RunTestDetails, reporterAPI) ([]jUnitTestReportSchema, error)
-	writeJUnitReport            func(*jUnitReportSchema, *os.File) error
+	getRunDetails           func(int, reporterAPI) (*rainforest.RunDetails, error)
+	createOutputFile        func(string) (*os.File, error)
+	createJUnitReportSchema func(*rainforest.RunDetails, reporterAPI) (*jUnitReportSchema, error)
+	writeJUnitReport        func(*jUnitReportSchema, *os.File) error
 }
 
 func createReport(c cliContext) error {
@@ -48,11 +47,10 @@ func postRunJUnitReport(c cliContext, runID int) error {
 
 func newReporter() *reporter {
 	return &reporter{
-		getRunDetails:               getRunDetails,
-		createOutputFile:            os.Create,
-		createJUnitReportSchema:     createJUnitReportSchema,
-		createJunitTestReportSchema: createJunitTestReportSchema,
-		writeJUnitReport:            writeJUnitReport,
+		getRunDetails:           getRunDetails,
+		createOutputFile:        os.Create,
+		createJUnitReportSchema: createJUnitReportSchema,
+		writeJUnitReport:        writeJUnitReport,
 	}
 }
 
@@ -166,49 +164,29 @@ type jUnitReportSchema struct {
 	TestCases []jUnitTestReportSchema
 }
 
-func createJUnitReportSchema(runDetails *rainforest.RunDetails, client reporterAPI) (*jUnitReportSchema, error) {
-	finalStateName := runDetails.StateDetails.Name
-	duration := runDetails.Timestamps[finalStateName].Sub(runDetails.Timestamps["created_at"]).Seconds()
-
-	testCases, err := createJunitTestReportSchema(runDetails.ID, runDetails.Tests, client)
-	if err != nil {
-		return &jUnitReportSchema{}, err
-	}
-
-	report := &jUnitReportSchema{
-		Name:      runDetails.Description,
-		Errors:    runDetails.TotalNoResultTests,
-		Failures:  runDetails.TotalFailedTests,
-		Tests:     runDetails.TotalTests,
-		TestCases: testCases,
-		Time:      duration,
-	}
-
-	return report, nil
-}
-
-func createJunitTestReportSchema(runID int, tests []rainforest.RunTestDetails, api reporterAPI) ([]jUnitTestReportSchema, error) {
+func createJUnitReportSchema(runDetails *rainforest.RunDetails, api reporterAPI) (*jUnitReportSchema, error) {
 	type processedTestCase struct {
 		TestCase jUnitTestReportSchema
 		Error    error
 	}
 
 	// Create channels for work to be done and results
-	processedTestChan := make(chan processedTestCase, len(tests))
-	testsChan := make(chan rainforest.RunTestDetails, len(tests))
+	testCount := len(runDetails.Tests)
+	processedTestChan := make(chan processedTestCase, testCount)
+	testsChan := make(chan rainforest.RunTestDetails, testCount)
 
 	processTestWorker := func(testsChan <-chan rainforest.RunTestDetails) {
 		for test := range testsChan {
 			testCase := jUnitTestReportSchema{}
 
-			duration := test.UpdatedAt.Sub(test.CreatedAt).Seconds()
+			testDuration := test.UpdatedAt.Sub(test.CreatedAt).Seconds()
 
 			testCase.Name = test.Title
-			testCase.Time = duration
+			testCase.Time = testDuration
 
 			if test.Result == "failed" {
 				log.Printf("Fetching information for failed test #" + strconv.Itoa(test.ID))
-				testDetails, err := api.GetRunTestDetails(runID, test.ID)
+				testDetails, err := api.GetRunTestDetails(runDetails.ID, test.ID)
 
 				if err != nil {
 					processedTestChan <- processedTestCase{TestCase: jUnitTestReportSchema{}, Error: err}
@@ -217,11 +195,9 @@ func createJunitTestReportSchema(runID int, tests []rainforest.RunTestDetails, a
 
 				for _, step := range testDetails.Steps {
 					for _, browser := range step.Browsers {
-						browserName := browser.Name
-
 						for _, feedback := range browser.Feedback {
 							if feedback.AnswerGiven == "no" && feedback.JobState == "approved" && feedback.Note != "" {
-								reportFailure := jUnitTestReportFailure{Type: browserName, Message: feedback.Note}
+								reportFailure := jUnitTestReportFailure{Type: browser.Name, Message: feedback.Note}
 								testCase.Failures = append(testCase.Failures, reportFailure)
 							}
 						}
@@ -239,24 +215,35 @@ func createJunitTestReportSchema(runID int, tests []rainforest.RunTestDetails, a
 	}
 
 	// give them work
-	for _, test := range tests {
+	for _, test := range runDetails.Tests {
 		testsChan <- test
 	}
 	close(testsChan)
 
 	// and collect the results
-	testCases := make([]jUnitTestReportSchema, len(tests))
-	for i := 0; i < len(tests); i++ {
+	testCases := make([]jUnitTestReportSchema, testCount)
+	for i := 0; i < testCount; i++ {
 		processed := <-processedTestChan
 
 		if processed.Error != nil {
-			return []jUnitTestReportSchema{}, processed.Error
+			return &jUnitReportSchema{}, processed.Error
 		}
 
 		testCases[i] = processed.TestCase
 	}
 
-	return testCases, nil
+	finalStateName := runDetails.StateDetails.Name
+	runDuration := runDetails.Timestamps[finalStateName].Sub(runDetails.Timestamps["created_at"]).Seconds()
+	report := &jUnitReportSchema{
+		Name:      runDetails.Description,
+		Errors:    runDetails.TotalNoResultTests,
+		Failures:  runDetails.TotalFailedTests,
+		Tests:     runDetails.TotalTests,
+		TestCases: testCases,
+		Time:      runDuration,
+	}
+
+	return report, nil
 }
 
 func writeJUnitReport(reportSchema *jUnitReportSchema, file *os.File) error {

--- a/reporter_test.go
+++ b/reporter_test.go
@@ -187,7 +187,7 @@ func TestCreateJUnitReportSchema(t *testing.T) {
 		},
 	}
 
-	// api should not be used so input shouldn't matter
+	// Dummy API - be used when there are no failed tests
 	api := newFakeReporterAPI(-1, []rainforest.RunTestDetails{})
 
 	schema, err := createJUnitReportSchema(&runDetails, api)
@@ -214,6 +214,20 @@ func TestCreateJUnitReportSchema(t *testing.T) {
 		t.Errorf("Expected: %#v", expectedSchema)
 		t.Errorf("Actual: %#v", schema)
 	}
+
+	// Run has no description
+	runDetails.Description = ""
+	schema, err = createJUnitReportSchema(&runDetails, api)
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
+	expectedSchemaName := fmt.Sprintf("Run #%v", runDetails.ID)
+	if schema.Name != expectedSchemaName {
+		t.Errorf("Unexpected schema name. Expected: %v. Got %v.", expectedSchemaName, schema.Name)
+	}
+
+	runDetails.Description = runDesc // add description to the run again for next tests
 
 	// With failures
 	failedBrowser := "chrome"

--- a/reporter_test.go
+++ b/reporter_test.go
@@ -153,64 +153,90 @@ func newFakeReporterAPI(runID int, runTestDetails []rainforest.RunTestDetails) *
 	}
 }
 
-func TestCreateJunitTestReportSchema(t *testing.T) {
+func TestCreateJUnitReportSchema(t *testing.T) {
 	// Without failures
-	runID := 999
-	runTestTitle := "My title"
-	updatedAt := time.Now()
-	createdAt := updatedAt.Add(-10 * time.Minute)
+	now := time.Now()
+	runDesc := "very descriptive description"
+	totalTests := 1
+	totalNoResultTests := 0
+	totalFailedTests := 0
+	stateName := "complete"
 
-	tests := []rainforest.RunTestDetails{
-		{
-			Title:     runTestTitle,
-			CreatedAt: createdAt,
-			UpdatedAt: updatedAt,
-			Result:    "passed",
+	runDetails := rainforest.RunDetails{
+		ID:                 123,
+		Description:        runDesc,
+		TotalTests:         totalTests,
+		TotalNoResultTests: totalNoResultTests,
+		TotalFailedTests:   totalFailedTests,
+		StateDetails: rainforest.RunStateDetails{
+			Name:         stateName,
+			IsFinalState: true,
+		},
+		Timestamps: map[string]time.Time{
+			"created_at":  now.Add(-30 * time.Minute),
+			"in_progress": now.Add(-25 * time.Minute),
+			stateName:     now,
+		},
+		Tests: []rainforest.RunTestDetails{
+			{
+				Title:     "My test title",
+				CreatedAt: now.Add(-25 * time.Minute),
+				UpdatedAt: now,
+				Result:    "passed",
+			},
 		},
 	}
 
-	// api should not be used in this test case
-	api := newFakeReporterAPI(0, []rainforest.RunTestDetails{})
+	// api should not be used so input shouldn't matter
+	api := newFakeReporterAPI(-1, []rainforest.RunTestDetails{})
 
-	schema, err := createJunitTestReportSchema(runID, tests, api)
+	schema, err := createJUnitReportSchema(&runDetails, api)
 	if err != nil {
 		t.Errorf("Unexpected error returned by createJunitTestReportSchema: %v", err)
 	}
 
-	testSchema := schema[0]
-	expectedTestSchema := jUnitTestReportSchema{
-		Name: runTestTitle,
-		Time: 10 * time.Minute.Seconds(),
-	}
-
-	if !reflect.DeepEqual(testSchema, expectedTestSchema) {
-		t.Error("Incorrect JUnitTestReportSchema returned by createJunitTestReportSchema")
-		t.Errorf("Expected: %#v", expectedTestSchema)
-		t.Errorf("Actual: %#v", testSchema)
-	}
-
-	// With failures
-	runTestID := 123
-	failedBrowser := "chrome"
-	failedNote := "This note should appear"
-
-	tests = []rainforest.RunTestDetails{
-		{
-			ID:        runTestID,
-			Title:     runTestTitle,
-			CreatedAt: createdAt,
-			UpdatedAt: updatedAt,
-			Result:    "failed",
+	expectedSchema := jUnitReportSchema{
+		Name:     runDesc,
+		Errors:   totalNoResultTests,
+		Failures: totalFailedTests,
+		Tests:    totalTests,
+		Time:     30 * time.Minute.Seconds(),
+		TestCases: []jUnitTestReportSchema{
+			{
+				Name: runDetails.Tests[0].Title,
+				Time: 25 * time.Minute.Seconds(),
+			},
 		},
 	}
 
+	if !reflect.DeepEqual(expectedSchema, *schema) {
+		t.Error("Incorrect JUnitTestReportSchema returned by createJunitTestReportSchema")
+		t.Errorf("Expected: %#v", expectedSchema)
+		t.Errorf("Actual: %#v", schema)
+	}
+
+	// With failures
+	failedBrowser := "chrome"
+	failedNote := "This note should appear"
+
+	runDetails.TotalFailedTests = 1
+
+	failedTest := rainforest.RunTestDetails{
+		ID:        999888,
+		Title:     "My failed test",
+		CreatedAt: now.Add(-25 * time.Minute),
+		UpdatedAt: now,
+		Result:    "failed",
+	}
+	runDetails.Tests = []rainforest.RunTestDetails{failedTest}
+
 	apiTests := []rainforest.RunTestDetails{
 		{
-			ID:        runTestID,
-			Title:     runTestTitle,
-			CreatedAt: createdAt,
-			UpdatedAt: updatedAt,
-			Result:    "failed",
+			ID:        failedTest.ID,
+			Title:     failedTest.Title,
+			CreatedAt: failedTest.CreatedAt,
+			UpdatedAt: failedTest.UpdatedAt,
+			Result:    failedTest.Result,
 			Steps: []rainforest.RunStepDetails{
 				{
 					Browsers: []rainforest.RunBrowserDetails{
@@ -240,31 +266,34 @@ func TestCreateJunitTestReportSchema(t *testing.T) {
 		},
 	}
 
-	api = newFakeReporterAPI(runID, apiTests)
+	api = newFakeReporterAPI(runDetails.ID, apiTests)
 
 	var out bytes.Buffer
 	log.SetOutput(&out)
-	schema, err = createJunitTestReportSchema(runID, tests, api)
+	schema, err = createJUnitReportSchema(&runDetails, api)
 	log.SetOutput(os.Stdout)
+
 	if err != nil {
 		t.Errorf("Unexpected error returned by createJunitTestReportSchema: %v", err)
 	}
 
-	testSchema = schema[0]
-	expectedTestSchema = jUnitTestReportSchema{
-		Name: runTestTitle,
-		Time: 10 * time.Minute.Seconds(),
-		Failures: []jUnitTestReportFailure{
-			{
-				Type:    failedBrowser,
-				Message: failedNote,
+	expectedSchema.Failures = 1
+	expectedSchema.TestCases = []jUnitTestReportSchema{
+		{
+			Name: failedTest.Title,
+			Time: 25 * time.Minute.Seconds(),
+			Failures: []jUnitTestReportFailure{
+				{
+					Type:    failedBrowser,
+					Message: failedNote,
+				},
 			},
 		},
 	}
 
-	if !reflect.DeepEqual(testSchema, expectedTestSchema) {
+	if !reflect.DeepEqual(expectedSchema, *schema) {
 		t.Error("Incorrect JUnitTestReportSchema returned by createJunitTestReportSchema")
-		t.Errorf("Expected: %#v", expectedTestSchema)
-		t.Errorf("Actual: %#v", testSchema)
+		t.Errorf("Expected: %#v", expectedSchema)
+		t.Errorf("Actual: %#v", schema)
 	}
 }

--- a/rfml_test.go
+++ b/rfml_test.go
@@ -258,8 +258,6 @@ func (t *testRfmlAPI) ClientToken() string {
 	return "abc123"
 }
 
-var errStub = errors.New("STUB")
-
 func (t *testRfmlAPI) CreateTest(_ *rainforest.RFTest) error {
 	// implement when needed
 	return errStub


### PR DESCRIPTION
Also did some minor refactoring since we weren't using the one of the methods attached to the reporter struct.