### PR TITLE
Report failures due to RF result overrides in JUnit reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Rainforest CLI Changelog
 
+## 2.8.3 - WIP
+- Correctly find and parse failed steps for JUnit reports.
+
 ## 2.8.2 - 2017-10-13
 - Add a default JUnit test suite name for runs without a description.
   - (b66a7aaeb952986f29303f0291e4c749d990bd36, @epaulet)

--- a/rainforest/rainforest.go
+++ b/rainforest/rainforest.go
@@ -169,6 +169,11 @@ func (c *Client) Do(req *http.Request, out interface{}) (*http.Response, error) 
 	// potential errors to the caller.
 	if out != nil {
 		err = json.NewDecoder(res.Body).Decode(out)
+
+		if err != nil {
+			fmt.Printf("DEBUG - %v\n\n", err.Error())
+			return res, err
+		}
 	}
 
 	c.LastResponseHeaders = res.Header

--- a/rainforest/reporter.go
+++ b/rainforest/reporter.go
@@ -7,9 +7,11 @@ import (
 
 // RunFeedback contains details about the feedback of a Run Step for a browser
 type RunFeedback struct {
-	AnswerGiven string `json:"answer_given"`
-	JobState    string `json:"job_state"`
-	Note        string `json:"note"`
+	JobState      string `json:"job_state"`
+	Result        string `json:"result"`
+	FailureNote   string `json:"note"`
+	Comment       string `json:"comment"`
+	CommentReason string `json:"comment_reason"`
 }
 
 // RunBrowserDetails contains details about a Browser of a Run Step

--- a/rainforest/reporter_test.go
+++ b/rainforest/reporter_test.go
@@ -116,14 +116,12 @@ func TestGetRunTestDetails(t *testing.T) {
 						Name: "chrome",
 						Feedback: []RunFeedback{
 							{
-								AnswerGiven: "no",
 								JobState:    "approved",
-								Note:        "did not work",
+								FailureNote: "did not work",
 							},
 							{
-								AnswerGiven: "yes",
 								JobState:    "rejected",
-								Note:        "it worked",
+								FailureNote: "",
 							},
 						},
 					},

--- a/reporter.go
+++ b/reporter.go
@@ -197,8 +197,21 @@ func createJUnitReportSchema(runDetails *rainforest.RunDetails, api reporterAPI)
 				for _, step := range testDetails.Steps {
 					for _, browser := range step.Browsers {
 						for _, feedback := range browser.Feedback {
-							if feedback.AnswerGiven == "no" && feedback.JobState == "approved" && feedback.Note != "" {
-								reportFailure := jUnitTestReportFailure{Type: browser.Name, Message: feedback.Note}
+							if feedback.Result != "failed" || feedback.JobState != "approved" {
+								continue
+							}
+
+							if feedback.FailureNote != "" {
+								reportFailure := jUnitTestReportFailure{Type: browser.Name, Message: feedback.FailureNote}
+								testCase.Failures = append(testCase.Failures, reportFailure)
+							} else if feedback.CommentReason != "" {
+								// The step failed due to a special comment type being selected
+								message := feedback.CommentReason
+
+								if feedback.Comment != "" {
+									message += ": " + feedback.Comment
+								}
+								reportFailure := jUnitTestReportFailure{Type: browser.Name, Message: message}
 								testCase.Failures = append(testCase.Failures, reportFailure)
 							}
 						}

--- a/reporter_test.go
+++ b/reporter_test.go
@@ -187,7 +187,7 @@ func TestCreateJUnitReportSchema(t *testing.T) {
 		},
 	}
 
-	// Dummy API - be used when there are no failed tests
+	// Dummy API - should not be used when there are no failed tests
 	api := newFakeReporterAPI(-1, []rainforest.RunTestDetails{})
 
 	schema, err := createJUnitReportSchema(&runDetails, api)
@@ -258,19 +258,19 @@ func TestCreateJUnitReportSchema(t *testing.T) {
 							Name: failedBrowser,
 							Feedback: []rainforest.RunFeedback{
 								{
-									AnswerGiven: "no",
+									Result:      "failed",
 									JobState:    "approved",
-									Note:        failedNote,
+									FailureNote: failedNote,
 								},
 								{
-									AnswerGiven: "yes",
+									Result:      "yes",
 									JobState:    "approved",
-									Note:        "This note should not appear",
+									FailureNote: "This note should not appear",
 								},
 								{
-									AnswerGiven: "no",
+									Result:      "no",
 									JobState:    "rejected",
-									Note:        "This note should not appear either",
+									FailureNote: "This note should not appear either",
 								},
 							},
 						},
@@ -281,15 +281,6 @@ func TestCreateJUnitReportSchema(t *testing.T) {
 	}
 
 	api = newFakeReporterAPI(runDetails.ID, apiTests)
-
-	var out bytes.Buffer
-	log.SetOutput(&out)
-	schema, err = createJUnitReportSchema(&runDetails, api)
-	log.SetOutput(os.Stdout)
-
-	if err != nil {
-		t.Errorf("Unexpected error returned by createJunitTestReportSchema: %v", err)
-	}
 
 	expectedSchema.Failures = 1
 	expectedSchema.TestCases = []jUnitTestReportSchema{
@@ -303,6 +294,83 @@ func TestCreateJUnitReportSchema(t *testing.T) {
 				},
 			},
 		},
+	}
+
+	var out bytes.Buffer
+	log.SetOutput(&out)
+	schema, err = createJUnitReportSchema(&runDetails, api)
+	log.SetOutput(os.Stdout)
+
+	if err != nil {
+		t.Errorf("Unexpected error returned by createJunitTestReportSchema: %v", err)
+	}
+
+	if !reflect.DeepEqual(expectedSchema, *schema) {
+		t.Error("Incorrect JUnitTestReportSchema returned by createJunitTestReportSchema")
+		t.Errorf("Expected: %#v", expectedSchema)
+		t.Errorf("Actual: %#v", schema)
+	}
+
+	// Failures due to Rainforest overriding tester result
+	commentReason := "unexpected_popup"
+	comment := "Where did this pop up come from?"
+	apiTests = []rainforest.RunTestDetails{
+		{
+			ID:        failedTest.ID,
+			Title:     failedTest.Title,
+			CreatedAt: failedTest.CreatedAt,
+			UpdatedAt: failedTest.UpdatedAt,
+			Result:    failedTest.Result,
+			Steps: []rainforest.RunStepDetails{
+				{
+					Browsers: []rainforest.RunBrowserDetails{
+						{
+							Name: failedBrowser,
+							Feedback: []rainforest.RunFeedback{
+								{
+									Result:        "failed",
+									JobState:      "approved",
+									CommentReason: commentReason,
+									Comment:       comment,
+								},
+								{
+									Result:   "passed",
+									JobState: "approved",
+								},
+								{
+									Result:      "failed",
+									JobState:    "rejected",
+									FailureNote: "This note should not appear either",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	api = newFakeReporterAPI(runDetails.ID, apiTests)
+
+	expectedSchema.TestCases = []jUnitTestReportSchema{
+		{
+			Name: failedTest.Title,
+			Time: 25 * time.Minute.Seconds(),
+			Failures: []jUnitTestReportFailure{
+				{
+					Type:    failedBrowser,
+					Message: fmt.Sprintf("%v: %v", commentReason, comment),
+				},
+			},
+		},
+	}
+
+	log.SetOutput(&out)
+	schema, err = createJUnitReportSchema(&runDetails, api)
+	log.SetOutput(os.Stdout)
+
+	if err != nil {
+		t.Errorf("Unexpected error returned by createJunitTestReportSchema: %v", err)
 	}
 
 	if !reflect.DeepEqual(expectedSchema, *schema) {


### PR DESCRIPTION
Since "no" does not always mean "failed" anymore on step results, I explicitly check for failure now and put together the appropriate failure message (either from the "note" attribute which is a failure message or the "comment" attribute which is the reason the step was flagged).