### PR TITLE
default -f flag value to false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Rainforest CLI Changelog
 
+## 2.8.4 - WIP
+- Default the value of the local file flag to false when not given.
+
 ## 2.8.3 - 2017-10-25
 - Correctly find and parse failed steps for JUnit reports.
   - 090e407a579e452d1c421a36c531cdd4de4bd60d, @epaulet)

--- a/rainforest-cli.go
+++ b/rainforest-cli.go
@@ -134,7 +134,7 @@ func main() {
 				"Alternatively you can use one of the filtering options.",
 			ArgsUsage: "[test IDs]",
 			Flags: []cli.Flag{
-				cli.BoolTFlag{
+				cli.BoolFlag{
 					Name:  "f, files",
 					Usage: "run local tests specified by `FILES or FOLDERS`",
 				},


### PR DESCRIPTION
To prevent cases like this

```
Edwards-MacBook-Pro:rainforest-cli edward$ rainforest run --folder 123
2017/10/26 10:53:48 folder cannot be specified with run -f
Edwards-MacBook-Pro:rainforest-cli edward$ rainforest -v
rainforest version 2.8.3 - stable channel - build: e2ca7e37
```