### PR TITLE
Fix index out of bounds when -f flag is the final flag in a command

### DIFF
--- a/rainforest-cli.go
+++ b/rainforest-cli.go
@@ -476,7 +476,7 @@ func shuffleFlags(originalArgs []string) []string {
 		} else if option == "-f" || option == "--files" {
 			rest = append(rest, option)
 			i++
-			for originalArgs[i][0] != '-' {
+			for i < len(originalArgs) && originalArgs[i][0] != '-' {
 				fnameArgs = append(fnameArgs, originalArgs[i])
 				i++
 			}

--- a/rainforest-cli_test.go
+++ b/rainforest-cli_test.go
@@ -41,6 +41,10 @@ func TestShuffleFlags(t *testing.T) {
 			testArgs: []string{"./rainforest", "run", "-f", "foo.rfml", "bar.rfml", "--token", "foobar"},
 			want:     []string{"./rainforest", "--token", "foobar", "run", "-f", "foo.rfml", "bar.rfml"},
 		},
+		{
+			testArgs: []string{"./rainforest", "run", "-f", "foo.rfml"},
+			want:     []string{"./rainforest", "run", "-f", "foo.rfml"},
+		},
 	}
 
 	for _, tCase := range testCases {


### PR DESCRIPTION
Should fix this problem:

```
$ rainforest run -f foo.rfml
panic: runtime error: index out of range

goroutine 1 [running]:
panic(0x351440, 0xc4200120e0)
	/usr/local/go/src/runtime/panic.go:500 +0x1a1
main.shuffleFlags(0xc42000a240, 0x4, 0x4, 0x533680, 0xc420014fa0, 0xc420017380)
	/home/ubuntu/.go_workspace/src/github.com/rainforestapp/rainforest-cli/rainforest-cli.go:479 +0x7dc
main.main()
	/home/ubuntu/.go_workspace/src/github.com/rainforestapp/rainforest-cli/rainforest-cli.go:452 +0x243e
```