### PR TITLE
Add a Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM golang:1.9.2
+WORKDIR /go/src/github.com/rainforestapp/rainforest-cli
+RUN curl -s https://glide.sh/get | sh
+ADD glide.yaml glide.lock ./
+RUN glide install
+COPY . .
+RUN go-wrapper install -ldflags "-X main.build=docker"
+
+ENTRYPOINT ["rainforest-cli", "--skip-update"]


### PR DESCRIPTION
This will make it easier for us to use CircleCI 2.0 internally, and
might also be generally useful for CI if it's in the Docker hub.