### PR TITLE
change filters checking logic

### DIFF
--- a/runner.go
+++ b/runner.go
@@ -101,7 +101,7 @@ func (r *runner) startRun(c cliContext) error {
 func (r *runner) prepareLocalRun(c cliContext) ([]*rainforest.RFTest, error) {
 	invalidFilters := []string{"folder", "feature", "run-group", "site"}
 	for _, filter := range invalidFilters {
-		if c.Int(filter) != 0 || c.String(filter) != "" {
+		if !(c.Int(filter) == 0 || c.String(filter) == "") {
 			return nil, fmt.Errorf("%s cannot be specified with run -f", filter)
 		}
 	}


### PR DESCRIPTION
Trying to do `-f filename.rfml` now leads to `2017/11/29 19:31:58 feature cannot be specified with run -f`.
`feature` defaults to `0` and when getting it as a string it's still `0`, so the logic that's there fails.
I reworked it in a way, that I think is what it was trying to check.