### PR TITLE
[bugfix] allow 0 as a string

### DIFF
--- a/runner.go
+++ b/runner.go
@@ -101,7 +101,7 @@ func (r *runner) startRun(c cliContext) error {
 func (r *runner) prepareLocalRun(c cliContext) ([]*rainforest.RFTest, error) {
 	invalidFilters := []string{"folder", "feature", "run-group", "site"}
 	for _, filter := range invalidFilters {
-		if c.Int(filter) != 0 || c.String(filter) != "" {
+		if c.Int(filter) != 0 || (c.String(filter) != "" && c.String(filter) != "0") {
 			return nil, fmt.Errorf("%s cannot be specified with run -f", filter)
 		}
 	}


### PR DESCRIPTION
Allows a case when an empty argument is converted to `"0"`.
Without this after casting `feature` to `0` resulted in `feature cannot be specified with run -f`.