### PR TITLE
Revert "RF-4314 remove unused generator fields to patch a time parsing issue"

### DIFF
--- a/rainforest/tabularvars.go
+++ b/rainforest/tabularvars.go
@@ -3,6 +3,7 @@ package rainforest
 import (
 	"errors"
 	"strconv"
+	"time"
 )
 
 // Generator is a type representing generators which can be used as variables in RF tests.
@@ -10,6 +11,7 @@ import (
 type Generator struct {
 	ID          int               `json:"id,omitempty"`
 	Name        string            `json:"name,omitempty"`
+	CreatedAt   time.Time         `json:"created_at,omitempty"`
 	Description string            `json:"description,omitempty"`
 	Type        string            `json:"generator_type,omitempty"`
 	SingleUse   bool              `json:"single_use,omitempty"`
@@ -30,6 +32,7 @@ func (g Generator) GetDescription() string {
 // GeneratorColumn is a type of column in a generator
 type GeneratorColumn struct {
 	ID        int       `json:"id,omitempty"`
+	CreatedAt time.Time `json:"created_at,omitempty"`
 	Name      string    `json:"name,omitempty"`
 }
 

--- a/rainforest/tabularvars_test.go
+++ b/rainforest/tabularvars_test.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestGetGenerators(t *testing.T) {
@@ -30,6 +31,7 @@ func TestGetGenerators(t *testing.T) {
 	want := []Generator{{
 		ID:          1337,
 		Name:        "foo",
+		CreatedAt:   time.Date(2016, time.November, 24, 14, 56, 19, 0, time.UTC),
 		Description: "bar",
 		Type:        "tabular",
 		SingleUse:   false,
@@ -38,10 +40,12 @@ func TestGetGenerators(t *testing.T) {
 			{
 				ID:        30225,
 				Name:      "username",
+				CreatedAt: time.Date(2016, time.November, 24, 14, 56, 19, 0, time.UTC),
 			},
 			{
 				ID:        30226,
 				Name:      "password",
+				CreatedAt: time.Date(2016, time.November, 24, 14, 56, 19, 0, time.UTC),
 			},
 		},
 	}}
@@ -102,6 +106,7 @@ func TestCreateTabularVar(t *testing.T) {
 	want := &Generator{
 		ID:          1337,
 		Name:        "foo",
+		CreatedAt:   time.Date(2016, time.November, 24, 14, 56, 19, 0, time.UTC),
 		Description: "bar",
 		Type:        "tabular",
 		SingleUse:   false,
@@ -110,10 +115,12 @@ func TestCreateTabularVar(t *testing.T) {
 			{
 				ID:        30225,
 				Name:      "baz",
+				CreatedAt: time.Date(2016, time.November, 24, 14, 56, 19, 0, time.UTC),
 			},
 			{
 				ID:        30226,
 				Name:      "wut",
+				CreatedAt: time.Date(2016, time.November, 24, 14, 56, 19, 0, time.UTC),
 			},
 		},
 	}
@@ -154,10 +161,12 @@ func TestAddGeneratorRows(t *testing.T) {
 			{
 				ID:        123,
 				Name:      "qwe",
+				CreatedAt: time.Date(2016, time.November, 24, 14, 56, 19, 0, time.UTC),
 			},
 			{
 				ID:        456,
 				Name:      "asd",
+				CreatedAt: time.Date(2016, time.November, 24, 14, 56, 19, 0, time.UTC),
 			},
 		},
 	}
@@ -199,10 +208,12 @@ func TestAddGeneratorRowsFromTable(t *testing.T) {
 			{
 				ID:        123,
 				Name:      "qwe",
+				CreatedAt: time.Date(2016, time.November, 24, 14, 56, 19, 0, time.UTC),
 			},
 			{
 				ID:        456,
 				Name:      "asd",
+				CreatedAt: time.Date(2016, time.November, 24, 14, 56, 19, 0, time.UTC),
 			},
 		},
 	}


### PR DESCRIPTION
The API issue has been addressed so this temporary fix can be reverted.