### PR TITLE
[RF-6316] return a cli.ExitError if rm command fails

### DIFF
--- a/rfml.go
+++ b/rfml.go
@@ -319,7 +319,8 @@ func deleteRFML(c cliContext) error {
 	rfmlReader := rainforest.NewRFMLReader(f)
 	parsedRFML, err := rfmlReader.ReadAll()
 	if err != nil {
-		return fileParseError{filePath, err}
+		errMsg := fmt.Sprintf("Error removing test at '%v': %v", filePath, err.Error())
+		return cli.NewExitError(errMsg, 1)
 	}
 
 	if parsedRFML.RFMLID == "" {

--- a/rfml_test.go
+++ b/rfml_test.go
@@ -422,6 +422,10 @@ func TestDeleteRFML(t *testing.T) {
 		t.Fatal("Expected parse error but received no error.")
 	}
 
+	if _, ok := err.(*cli.ExitError); !ok {
+		t.Fatalf("Unexpected error type: %v", reflect.TypeOf(err))
+	}
+
 	errMsg := err.Error()
 	if !strings.Contains(errMsg, rfmlFilePath) {
 		t.Errorf("Expected error to contain file path \"%v\". Got:\n%v", rfmlFilePath, errMsg)


### PR DESCRIPTION
Currently it fails silently.