### PR TITLE
Update app name

### DIFF
--- a/rainforest-cli.go
+++ b/rainforest-cli.go
@@ -70,6 +70,7 @@ func (l *logWriter) Write(p []byte) (int, error) {
 func main() {
 	updateFinishedChan := make(chan struct{})
 	app := cli.NewApp()
+	app.Name = "Rainforest CLI"
 	app.Usage = "Rainforest QA CLI - https://www.rainforestqa.com/"
 	app.Version = version
 	if releaseChannel != "" {


### PR DESCRIPTION
The CLI messages show up correctly this way.

Before
```bash
$ go build -o testing *.go && ./testing --skip-update --version
testing version 2.10.2
```

After
```bash
$ go build -o testing *.go && ./testing --skip-update --version
Rainforest CLI version 2.10.2
```