### PR TITLE
RF-10851 remove local test state validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Rainforest CLI Changelog
 
+## 2.10.3 - 2019-01-16
+- Remove local validation for RFML state attribute so that the API will validate it instead.
+  - (ac67e3d4c3f6f7d8df2ea465c3741980dfc16af2, @epaulet, @jbarber)
+
 ## 2.10.2 - 2019-01-14
 - Use `include_feedback` and `skip_mark_as_viewed` query params when fetching run results in order to get details of failures and not update the results state to `viewed`.
   - (c76cb1dea35677f951dc22bc1b3ed3b7895bb569, @epaulet)

--- a/rainforest-cli.go
+++ b/rainforest-cli.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	// Version of the app in SemVer
-	version = "2.10.2"
+	version = "2.10.3"
 	// This is the default spec folder for RFML tests
 	defaultSpecFolder = "./spec/rainforest"
 )

--- a/rainforest/rfml.go
+++ b/rainforest/rfml.go
@@ -139,13 +139,7 @@ func (r *RFMLReader) ReadAll() (*RFTest, error) {
 					}
 					parsedRFTest.FeatureID = FeatureIDInt(featureID)
 				case "state":
-					if value == "disabled" {
-						parsedRFTest.State = "disabled"
-					} else if value == "enabled" {
-						parsedRFTest.State = "enabled"
-					} else {
-						return parsedRFTest, &parseError{lineNumStr, "Test state must be \"enabled\" or \"disabled\""}
-					}
+					parsedRFTest.State = value
 				case "execute":
 					execute, err := strconv.ParseBool(value)
 					if err != nil {

--- a/rainforest/rfml_test.go
+++ b/rainforest/rfml_test.go
@@ -91,7 +91,7 @@ func TestReadAll(t *testing.T) {
 		t.Errorf("Incorrect values for RFTest.\nGot %#v\nWant %#v", rfTest, validTestValues)
 	}
 
-	// Test is disabled
+	// Test state is present
 	testText = fmt.Sprintf(`#! %v
 # title: %v
 # start_uri: %v
@@ -100,7 +100,7 @@ func TestReadAll(t *testing.T) {
 		validTestValues.RFMLID,
 		validTestValues.Title,
 		validTestValues.StartURI,
-		"disabled",
+		"some_state",
 	)
 
 	r = strings.NewReader(testText)
@@ -110,8 +110,8 @@ func TestReadAll(t *testing.T) {
 		t.Fatal(err.Error())
 	}
 
-	if rfTest.State != "disabled" {
-		t.Errorf("Incorrect test state. Got %v, Want %v", rfTest.State, "disabled")
+	if rfTest.State != "some_state" {
+		t.Errorf("Incorrect test state. Got %v, Want %v", rfTest.State, "some_state")
 	}
 
 	// Test state is omitted


### PR DESCRIPTION
The API validates the state parameter already so the local validation is unnecessary.