### PR TITLE
RF-14712 automation crowd flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ Popular command line options are:
 - `--environment-id` - run your tests using this environment. Otherwise it will use your default environment
 - `--conflict OPTION` - use the `abort` option to abort any runs in progress in the same environment as your new run. use the `abort-all` option to abort all runs in progress.
 - `--bg` - creates a run in the background and rainforest-cli exits immediately after. Do not use if you want rainforest-cli to track your run and exit with an error code upon run failure (ie: using Rainforest in your CI environment).
-- `--crowd [default|on_premise_crowd]` - select your crowd of testers for clients with on premise testers. For more information, contact us at help@rainforestqa.com.
+- `--crowd [default|automation|on_premise_crowd]` - select automation or your crowd of testers (for clients with on premise testers). For more information, contact us at help@rainforestqa.com.
 - `--wait RUN_ID` - wait for an existing run to finish instead of starting a new one, and exit with a non-0 code if the run fails. rainforest-cli will exit immediately if the run is already complete.
 - `--fail-fast` - fail the build as soon as the first failed result comes in. If you don't pass this it will wait until 100% of the run is done. Has no effect with `--bg`.
 - `--custom-url` - use a custom url for this run to use an ad-hoc QA environment on all tests. You will need to specify a `site_id` too for this to work. Note that we will be creating a new environment for your account for this particular run.

--- a/rainforest-cli.go
+++ b/rainforest-cli.go
@@ -180,7 +180,7 @@ func main() {
 				cli.StringFlag{
 					Name:  "crowd",
 					Value: "default",
-					Usage: "run your tests using specified `CROWD`. Available choices are: default or on_premise_crowd. " +
+					Usage: "run your tests using specified `CROWD`. Available choices are: default, automation or on_premise_crowd. " +
 						"Contact your CSM for more details.",
 				},
 				cli.StringFlag{

--- a/runner.go
+++ b/runner.go
@@ -289,7 +289,7 @@ func (r *runner) makeRunParams(c cliContext, localTests []*rainforest.RFTest) (r
 	}
 
 	var crowd string
-	if crowd = c.String("crowd"); crowd != "" && crowd != "default" && crowd != "on_premise_crowd" {
+	if crowd = c.String("crowd"); crowd != "" && crowd != "default" && crowd != "on_premise_crowd" && crowd != "automation" {
 		return rainforest.RunParams{}, errors.New("Invalid crowd option specified")
 	}
 

--- a/runner_test.go
+++ b/runner_test.go
@@ -234,6 +234,14 @@ func TestMakeRunParams(t *testing.T) {
 				RunGroupID: 75,
 			},
 		},
+		{
+			mappings: map[string]interface{}{
+				"crowd": "automation",
+			},
+			expected: rainforest.RunParams{
+				Crowd: "automation",
+			},
+		},
 	}
 
 	for _, testCase := range testCases {


### PR DESCRIPTION
Supports executing tests with RF automation via `--crowd automation` option to replicate select options from the UI.

The cli prints the known error If requested tests are missing screenshots or contain english steps
```
2019/07/19 12:30:32 RF API Error (400): Requested automation, but tests [2] are not automated
```