### PR TITLE
[RF-18165] Add rerun command

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ rainforest run --run-group <run_group_id>
 
 Rerun failed tests from a run.
 
+If you don't pass in an argument, it will try to get a run ID from the `RAINFOREST_RUN_ID` environment variable.
+
 ```bash
 rainforest rerun <failed_run_id>
 ```

--- a/README.md
+++ b/README.md
@@ -89,6 +89,12 @@ Run a run group.
 rainforest run --run-group <run_group_id>
 ```
 
+Rerun failed tests from a run.
+
+```bash
+rainforest rerun <failed_run_id>
+```
+
 #### Creating and Managing Tests
 
 Create new Rainforest test in RFML format (Rainforest Markup Language).

--- a/README.md
+++ b/README.md
@@ -81,6 +81,14 @@ Run individual tests in the foreground and report.
 rainforest run <test_id1> <test_id2>
 ```
 
+Run a run group.
+
+⚠️ This uses the configuration defined in the run group (environment, browsers, crowd, location). If you wish to run tests from a run group without using the run group's configuration, you will need to use the Rainforest API directly, passing a `run_group_id` parameter to [the `POST /runs` endpoint](https://app.rainforestqa.com/docs#!/runs/post1Runs). ⚠️
+
+```bash
+rainforest run --run-group <run_group_id>
+```
+
 #### Creating and Managing Tests
 
 Create new Rainforest test in RFML format (Rainforest Markup Language).

--- a/rainforest-cli.go
+++ b/rainforest-cli.go
@@ -250,6 +250,37 @@ func main() {
 			},
 		},
 		{
+			Name:         "rerun",
+			Aliases:      []string{"rr"},
+			Usage:        "Rerun failed tests from a previous run",
+			OnUsageError: onCommandUsageErrorHandler("rerun"),
+			Action:       rerunRun,
+			Description: "Reruns the failed tests from a previous run on Rainforest platform. " +
+				"Parameters such as 'environment', 'crowd', 'release', etc. are copied from the previous run.",
+			ArgsUsage: "[run ID]",
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name: "conflict",
+					Usage: "use the abort option to abort any runs in the same environment or " +
+						"use the abort-all option to abort all runs in progress.",
+				},
+				cli.BoolFlag{
+					Name: "bg, background",
+					Usage: "run in the background. This option makes cli return after successfully starting a run, " +
+						"without waiting for the run results.",
+				},
+				cli.BoolFlag{
+					Name: "fail-fast, ff",
+					Usage: "fail the build as soon as the first failed result comes in. " +
+						"If you don't pass this it will wait until 100% of the run is done. Use with --fg.",
+				},
+				cli.StringFlag{
+					Name:  "junit-file",
+					Usage: "Create a JUnit XML report `FILE` with the specified name. Must be run in foreground mode.",
+				},
+			},
+		},
+		{
 			Name:         "new",
 			Usage:        "Create a new RFML test",
 			OnUsageError: onCommandUsageErrorHandler("new"),

--- a/rainforest-cli_test.go
+++ b/rainforest-cli_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestMain(t *testing.T) {
-	commands := []string{"run", "new", "validate", "upload", "rm", "download", "csv-upload", "mobile-upload", "report", "sites", "environments", "folders", "filters", "browsers", "features", "run-groups", "update"}
+	commands := []string{"run", "rerun", "new", "validate", "upload", "rm", "download", "csv-upload", "mobile-upload", "report", "sites", "environments", "folders", "filters", "browsers", "features", "run-groups", "update"}
 
 	for _, command := range commands {
 		if os.Getenv("TEST_EXIT") == "1" {

--- a/rainforest/runner.go
+++ b/rainforest/runner.go
@@ -76,20 +76,26 @@ func (c *Client) CreateRun(params RunParams) (*RunStatus, error) {
 }
 
 func validateRerunParams(params RunParams) error {
-	if params.Tags != nil {
-		return errors.New("Tags cannot be specified for rerun")
-	}
-	if params.Browsers != nil {
-		return errors.New("Browsers cannot be specified for rerun")
-	}
 	if params.Tests != nil {
 		return errors.New("Tests cannot be specified for rerun")
 	}
 	if params.RFMLIDs != nil {
 		return errors.New("RFML tests cannot be specified for rerun")
 	}
+	if params.Tags != nil {
+		return errors.New("Tags cannot be specified for rerun")
+	}
+	if params.SmartFolderID != 0 {
+		return errors.New("Folder cannot be specified for rerun")
+	}
+	if params.SiteID != 0 {
+		return errors.New("Site cannot be specified for rerun")
+	}
 	if params.Crowd != "" {
 		return errors.New("Crowd cannot be specified for rerun")
+	}
+	if params.Browsers != nil {
+		return errors.New("Browsers cannot be specified for rerun")
 	}
 	if params.Description != "" {
 		return errors.New("Description cannot be specified for rerun")
@@ -100,14 +106,8 @@ func validateRerunParams(params RunParams) error {
 	if params.EnvironmentID != 0 {
 		return errors.New("Environment cannot be specified for rerun")
 	}
-	if params.SiteID != 0 {
-		return errors.New("Site cannot be specified for rerun")
-	}
 	if params.FeatureID != 0 {
 		return errors.New("Feature cannot be specified for rerun")
-	}
-	if params.SmartFolderID != 0 {
-		return errors.New("Folder cannot be specified for rerun")
 	}
 	if params.RunGroupID != 0 {
 		return errors.New("Run Group cannot be specified for rerun")
@@ -117,23 +117,23 @@ func validateRerunParams(params RunParams) error {
 }
 
 func validateRunGroupParams(params RunParams) error {
+	if params.Tests != nil {
+		return errors.New("Tests cannot be specified alongside run group")
+	}
 	if params.Tags != nil {
 		return errors.New("Tags cannot be specified alongside run group")
 	}
-	if params.Browsers != nil {
-		return errors.New("Browsers cannot be specified alongside run group")
-	}
-	if params.Tests != nil {
-		return errors.New("Tests cannot be specified alongside run group")
+	if params.SmartFolderID != 0 {
+		return errors.New("Folder cannot be specified alongside run group")
 	}
 	if params.SiteID != 0 {
 		return errors.New("Site cannot be specified alongside run group")
 	}
+	if params.Browsers != nil {
+		return errors.New("Browsers cannot be specified alongside run group")
+	}
 	if params.FeatureID != 0 {
 		return errors.New("Feature cannot be specified alongside run group")
-	}
-	if params.SmartFolderID != 0 {
-		return errors.New("Folder cannot be specified alongside run group")
 	}
 
 	return nil

--- a/rainforest/runner.go
+++ b/rainforest/runner.go
@@ -22,6 +22,7 @@ type RunParams struct {
 	EnvironmentID int         `json:"environment_id,omitempty"`
 	FeatureID     int         `json:"feature_id,omitempty"`
 	RunGroupID    int         `json:"-"`
+	RunID         int         `json:"-"`
 }
 
 // RunStatus represents a status of a RF run in progress.
@@ -47,7 +48,13 @@ func (c *Client) CreateRun(params RunParams) (*RunStatus, error) {
 	var runStatus RunStatus
 
 	endpoint := "runs"
-	if params.RunGroupID > 0 {
+	if params.RunID > 0 {
+		err := validateRerunParams(params)
+		if err != nil {
+			return &runStatus, err
+		}
+		endpoint = fmt.Sprintf("runs/%v/rerun_failed", params.RunID)
+	} else if params.RunGroupID > 0 {
 		err := validateRunGroupParams(params)
 		if err != nil {
 			return &runStatus, err
@@ -66,6 +73,47 @@ func (c *Client) CreateRun(params RunParams) (*RunStatus, error) {
 	}
 
 	return &runStatus, nil
+}
+
+func validateRerunParams(params RunParams) error {
+	if params.Tags != nil {
+		return errors.New("Tags cannot be specified for rerun")
+	}
+	if params.Browsers != nil {
+		return errors.New("Browsers cannot be specified for rerun")
+	}
+	if params.Tests != nil {
+		return errors.New("Tests cannot be specified for rerun")
+	}
+	if params.RFMLIDs != nil {
+		return errors.New("RFML tests cannot be specified for rerun")
+	}
+	if params.Crowd != "" {
+		return errors.New("Crowd cannot be specified for rerun")
+	}
+	if params.Description != "" {
+		return errors.New("Description cannot be specified for rerun")
+	}
+	if params.Release != "" {
+		return errors.New("Release cannot be specified for rerun")
+	}
+	if params.EnvironmentID != 0 {
+		return errors.New("Environment cannot be specified for rerun")
+	}
+	if params.SiteID != 0 {
+		return errors.New("Site cannot be specified for rerun")
+	}
+	if params.FeatureID != 0 {
+		return errors.New("Feature cannot be specified for rerun")
+	}
+	if params.SmartFolderID != 0 {
+		return errors.New("Folder cannot be specified for rerun")
+	}
+	if params.RunGroupID != 0 {
+		return errors.New("Run Group cannot be specified for rerun")
+	}
+
+	return nil
 }
 
 func validateRunGroupParams(params RunParams) error {

--- a/rainforest/runner_test.go
+++ b/rainforest/runner_test.go
@@ -159,7 +159,6 @@ func TestCreateRunFromRerun(t *testing.T) {
 			t.Errorf("Expected error for params %v but there was no error", params)
 		}
 	}
-	cleanup()
 }
 
 func TestCreateRunFromRunGroup(t *testing.T) {
@@ -248,7 +247,6 @@ func TestCreateRunFromRunGroup(t *testing.T) {
 			t.Errorf("Expected error for params %v but there was no error", params)
 		}
 	}
-	cleanup()
 }
 
 func TestCheckRunStatus(t *testing.T) {

--- a/rainforest/runner_test.go
+++ b/rainforest/runner_test.go
@@ -51,6 +51,117 @@ func TestCreateRun(t *testing.T) {
 	}
 }
 
+func TestCreateRunFromRerun(t *testing.T) {
+	setup()
+	defer cleanup()
+
+	const reqMethod = "POST"
+	runID := 42
+	var completed = false
+
+	runParams := RunParams{
+		RunID:    runID,
+		Conflict: "abort",
+	}
+	wantBody := `{"conflict":"abort"}`
+
+	mux.HandleFunc("/runs", func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("/runs endpoint hit, expected /runs/:id/rerun_failed")
+	})
+
+	wantPath := fmt.Sprintf("/runs/%v/rerun_failed", runID)
+	mux.HandleFunc(wantPath, func(w http.ResponseWriter, r *http.Request) {
+		completed = true
+		if r.Method != reqMethod {
+			t.Errorf("Request method = %v, want %v", r.Method, reqMethod)
+		}
+
+		buf := new(bytes.Buffer)
+		buf.ReadFrom(r.Body)
+		s := strings.TrimSpace(buf.String())
+		if s != wantBody {
+			t.Errorf("Request body = %v, want %v", s, wantBody)
+		}
+		fmt.Fprint(w, `{"id": 123, "state":"in_progress"}`)
+	})
+	out, err := client.CreateRun(runParams)
+	if err != nil {
+		t.Error("Error creating run:", err)
+	}
+
+	wantStatus := &RunStatus{ID: 123, State: "in_progress"}
+	if !reflect.DeepEqual(out, wantStatus) {
+		t.Errorf("Response out = %v, want %v", out, wantStatus)
+	}
+
+	if !completed {
+		t.Error("Run API endpoint not hit")
+	}
+
+	runID = 117
+	// Check that you can't combine filters
+	badParams := []RunParams{
+		{
+			RunID: runID,
+			Tags:  []string{"foo"},
+		},
+		{
+			RunID:    runID,
+			Browsers: []string{"chrome"},
+		},
+		{
+			RunID: runID,
+			Tests: "all",
+		},
+		{
+			RunID:   runID,
+			RFMLIDs: []string{"rmfl1"},
+		},
+		{
+			RunID: runID,
+			Crowd: "automation",
+		},
+		{
+			RunID:       runID,
+			Description: "My fancy rerun",
+		},
+		{
+			RunID:   runID,
+			Release: "somerandomsha",
+		},
+		{
+			RunID:         runID,
+			EnvironmentID: 35,
+		},
+		{
+			RunID:  runID,
+			SiteID: 35,
+		},
+		{
+			RunID:     runID,
+			FeatureID: 35,
+		},
+		{
+			RunID:         runID,
+			SmartFolderID: 123,
+		},
+		{
+			RunID:      runID,
+			RunGroupID: 123,
+		},
+	}
+	mux.HandleFunc(fmt.Sprintf("/runs/%v/rerun_failed", runID), func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{"id": 123, "state":"in_progress"}`)
+	})
+	for _, params := range badParams {
+		_, err := client.CreateRun(params)
+		if err == nil {
+			t.Errorf("Expected error for params %v but there was no error", params)
+		}
+	}
+	cleanup()
+}
+
 func TestCreateRunFromRunGroup(t *testing.T) {
 	setup()
 	defer cleanup()

--- a/reporter.go
+++ b/reporter.go
@@ -150,6 +150,7 @@ type jUnitTestReportFailure struct {
 
 type jUnitTestReportSchema struct {
 	XMLName  xml.Name `xml:"testcase"`
+	ID       int      `xml:"id,attr"`
 	Name     string   `xml:"name,attr"`
 	Time     float64  `xml:"time,attr"`
 	Failures []jUnitTestReportFailure
@@ -157,6 +158,7 @@ type jUnitTestReportSchema struct {
 
 type jUnitReportSchema struct {
 	XMLName   xml.Name `xml:"testsuite"`
+	ID        int      `xml:"id,attr"`
 	Name      string   `xml:"name,attr"`
 	Tests     int      `xml:"tests,attr"`
 	Errors    int      `xml:"errors,attr"`
@@ -182,6 +184,7 @@ func createJUnitReportSchema(runDetails *rainforest.RunDetails, api reporterAPI)
 
 			testDuration := test.UpdatedAt.Sub(test.CreatedAt).Seconds()
 
+			testCase.ID = test.ID
 			testCase.Name = test.Title
 			testCase.Time = testDuration
 
@@ -260,6 +263,7 @@ func createJUnitReportSchema(runDetails *rainforest.RunDetails, api reporterAPI)
 	finalStateName := runDetails.StateDetails.Name
 	runDuration := runDetails.Timestamps[finalStateName].Sub(runDetails.Timestamps["created_at"]).Seconds()
 	report := &jUnitReportSchema{
+		ID:        runDetails.ID,
 		Errors:    runDetails.TotalNoResultTests,
 		Failures:  runDetails.TotalFailedTests,
 		Tests:     runDetails.TotalTests,

--- a/reporter_test.go
+++ b/reporter_test.go
@@ -180,6 +180,7 @@ func TestCreateJUnitReportSchema(t *testing.T) {
 		},
 		Tests: []rainforest.RunTestDetails{
 			{
+				ID:        456,
 				Title:     "My test title",
 				CreatedAt: now.Add(-25 * time.Minute),
 				UpdatedAt: now,
@@ -197,6 +198,7 @@ func TestCreateJUnitReportSchema(t *testing.T) {
 	}
 
 	expectedSchema := jUnitReportSchema{
+		ID:       runDetails.ID,
 		Name:     runDesc,
 		Errors:   totalNoResultTests,
 		Failures: totalFailedTests,
@@ -204,6 +206,7 @@ func TestCreateJUnitReportSchema(t *testing.T) {
 		Time:     30 * time.Minute.Seconds(),
 		TestCases: []jUnitTestReportSchema{
 			{
+				ID:   runDetails.Tests[0].ID,
 				Name: runDetails.Tests[0].Title,
 				Time: 25 * time.Minute.Seconds(),
 			},
@@ -291,6 +294,7 @@ func TestCreateJUnitReportSchema(t *testing.T) {
 	expectedSchema.Failures = 1
 	expectedSchema.TestCases = []jUnitTestReportSchema{
 		{
+			ID:   failedTest.ID,
 			Name: failedTest.Title,
 			Time: 25 * time.Minute.Seconds(),
 			Failures: []jUnitTestReportFailure{
@@ -374,6 +378,7 @@ func TestCreateJUnitReportSchema(t *testing.T) {
 	expectedSchema.Failures = 1
 	expectedSchema.TestCases = []jUnitTestReportSchema{
 		{
+			ID:   failedTest.ID,
 			Name: failedTest.Title,
 			Time: 25 * time.Minute.Seconds(),
 			Failures: []jUnitTestReportFailure{
@@ -443,6 +448,7 @@ func TestCreateJUnitReportSchema(t *testing.T) {
 
 	expectedSchema.TestCases = []jUnitTestReportSchema{
 		{
+			ID:   failedTest.ID,
 			Name: failedTest.Title,
 			Time: 25 * time.Minute.Seconds(),
 			Failures: []jUnitTestReportFailure{

--- a/runner.go
+++ b/runner.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"net/url"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -403,9 +404,12 @@ func (r *runner) makeRunParams(c cliContext, localTests []*rainforest.RFTest) (r
 func (r *runner) makeRerunParams(c cliContext) (rainforest.RunParams, error) {
 	var err error
 
-	var runIDString string
 	var runID int
-	if runIDString = c.Args().First(); runIDString == "" {
+	runIDString := c.Args().First()
+	if runIDString == "" {
+		runIDString = os.Getenv("RAINFOREST_RUN_ID")
+	}
+	if runIDString == "" {
 		return rainforest.RunParams{}, errors.New("Missing run ID")
 	}
 	runID, err = strconv.Atoi(runIDString)

--- a/runner.go
+++ b/runner.go
@@ -320,8 +320,8 @@ func (r *runner) makeRunParams(c cliContext, localTests []*rainforest.RFTest) (r
 	}
 
 	var conflict string
-	if conflict = c.String("conflict"); conflict != "" && conflict != "abort" && conflict != "abort-all" {
-		return rainforest.RunParams{}, errors.New("Invalid conflict option specified")
+	if conflict, err = getConflict(c); err != nil {
+		return rainforest.RunParams{}, err
 	}
 
 	featureID := c.Int("feature")
@@ -418,8 +418,8 @@ func (r *runner) makeRerunParams(c cliContext) (rainforest.RunParams, error) {
 	}
 
 	var conflict string
-	if conflict = c.String("conflict"); conflict != "" && conflict != "abort" && conflict != "abort-all" {
-		return rainforest.RunParams{}, errors.New("Invalid conflict option specified")
+	if conflict, err = getConflict(c); err != nil {
+		return rainforest.RunParams{}, err
 	}
 
 	return rainforest.RunParams{
@@ -450,6 +450,16 @@ func stringToIntSlice(s string) ([]int, error) {
 func getTags(c cliContext) []string {
 	tags := c.StringSlice("tag")
 	return expandStringSlice(tags)
+}
+
+// getConflict gets conflict from a CLI context. It returns an error if value isn't allowed
+func getConflict(c cliContext) (string, error) {
+	var conflict string
+	if conflict = c.String("conflict"); conflict != "" && conflict != "abort" && conflict != "abort-all" {
+		return "", errors.New("Invalid conflict option specified")
+	}
+
+	return conflict, nil
 }
 
 // expandStringSlice takes a slice of strings and expands any comma separated sublists

--- a/runner_test.go
+++ b/runner_test.go
@@ -268,11 +268,26 @@ func TestMakeRunParams(t *testing.T) {
 }
 
 func TestMakeRerunParams(t *testing.T) {
+	envRunID, isSet := os.LookupEnv("RAINFOREST_RUN_ID")
+	if isSet {
+		defer os.Setenv("RAINFOREST_RUN_ID", envRunID)
+	} else {
+		defer os.Unsetenv("RAINFOREST_RUN_ID")
+	}
+	os.Setenv("RAINFOREST_RUN_ID", "117")
+
 	var testCases = []struct {
 		mappings map[string]interface{}
 		args     cli.Args
 		expected rainforest.RunParams
 	}{
+		{
+			mappings: make(map[string]interface{}),
+			args:     cli.Args{},
+			expected: rainforest.RunParams{
+				RunID: 117,
+			},
+		},
 		{
 			mappings: make(map[string]interface{}),
 			args:     cli.Args{"41"},

--- a/runner_test.go
+++ b/runner_test.go
@@ -267,6 +267,46 @@ func TestMakeRunParams(t *testing.T) {
 	}
 }
 
+func TestMakeRerunParams(t *testing.T) {
+	var testCases = []struct {
+		mappings map[string]interface{}
+		args     cli.Args
+		expected rainforest.RunParams
+	}{
+		{
+			mappings: make(map[string]interface{}),
+			args:     cli.Args{"41"},
+			expected: rainforest.RunParams{
+				RunID: 41,
+			},
+		},
+		{
+			mappings: map[string]interface{}{
+				"conflict": "abort",
+			},
+			args: cli.Args{"82"},
+			expected: rainforest.RunParams{
+				RunID:    82,
+				Conflict: "abort",
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		c := newFakeContext(testCase.mappings, testCase.args)
+		r := newRunner()
+		fakeEnv := rainforest.Environment{ID: 2401, Name: "the foo environment"}
+		r.client = &fakeRunnerClient{environment: fakeEnv}
+		res, err := r.makeRerunParams(c)
+
+		if err != nil {
+			t.Errorf("Error trying to create params: %v", err)
+		} else if !reflect.DeepEqual(res, testCase.expected) {
+			t.Errorf("Incorrect resulting run params.\nActual: %#v\nExpected: %#v", res, testCase.expected)
+		}
+	}
+}
+
 func TestStartLocalRun(t *testing.T) {
 	rfmlDir := setupTestRFMLDir()
 	defer os.RemoveAll(rfmlDir)


### PR DESCRIPTION
We've had the endpoint for ages, but a wrapper for it was never added to the CLI (until now 🎉). The implementation and tests are heavily inspired by the "create a run from a run group" flow.

```bash
> ./rainforest-cli rerun 622054 --debug
Trying https://app.rainforestqa.com/api/1/runs/622054/rerun_failed...connected
POST HTTP/1.1
User Agent: rainforest-cli/2.15.3 [rainforest golang lib/2.0.0]
Host: app.rainforestqa.com

2020/07/03 21:59:32 Run 622146 has been created.
```
=> https://app.rainforestqa.com/runs/622146

This also adds `id` attributes to the `testsuite` and `testcase` nodes of the JUnit file, to make it real easy to get the created run ID when using the `--junit-file` option:
```bash
> ./rainforest-cli rerun 622054 --junit-file results.xml
...
> xmllint --xpath "string(testsuite/@id)" results.xml
622146
```