### PR TITLE
Remove default value for --crowd flag

### DIFF
--- a/rainforest-cli.go
+++ b/rainforest-cli.go
@@ -184,8 +184,7 @@ func main() {
 					Usage: "run your tests using specified `ENVIRONMENT`. Otherwise it will use your default one.",
 				},
 				cli.StringFlag{
-					Name:  "crowd",
-					Value: "default",
+					Name: "crowd",
 					Usage: "run your tests using specified `CROWD`. Available choices are: default, automation, automation_and_crowd " +
 						"or on_premise_crowd. Contact your CSM for more details.",
 				},


### PR DESCRIPTION
The `POST /runs` endpoint defaults to `default` if no `crowd` param is passed in, so this PR will not result in any change in behavior for runs created via that endpoint.

The `POST /run_groups/:id/runs` endpoint defaults to the run group's `crowd` setting, so the only change will be for anyone creating runs for a run group with a non-`default` `crowd` setting while not passing in a `--crowd` flag. Those runs are currently created with the `default` crowd, and will now be whatever the run group's `crowd` setting is.