### PR TITLE
[RF-4338] Properly call equinox publish when releasing stable or beta versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,8 +30,8 @@ jobs:
           command: |
             echo -e $EQUINOX_KEY > equinox.key
             equinox release --version=${CIRCLE_TAG:1} --platforms="darwin_amd64 linux_amd64 darwin_386 linux_386 windows_amd64 windows_386" --signing-key=equinox.key --app=$EQUINOX_APP_ID --token=$EQUINOX_ACC_TOKEN --channel stable -- -ldflags "-X main.releaseChannel=stable -X main.build=${CIRCLE_SHA1:0:8}" github.com/rainforestapp/rainforest-cli
-            equinox publish --token=$EQUINOX_ACC_TOKEN --app=$EQUINOX_APP_ID --channel beta --version=${CIRCLE_TAG:1}
-            equinox publish --token=$EQUINOX_ACC_TOKEN --app=$EQUINOX_APP_ID --channel dev --version=${CIRCLE_TAG:1}
+            equinox publish --token=$EQUINOX_ACC_TOKEN --app=$EQUINOX_APP_ID --channel beta --release=${CIRCLE_TAG:1}
+            equinox publish --token=$EQUINOX_ACC_TOKEN --app=$EQUINOX_APP_ID --channel dev --release=${CIRCLE_TAG:1}
             rm -f equinox.key
 
   deploy_beta:
@@ -45,7 +45,7 @@ jobs:
           command: |
             echo -e $EQUINOX_KEY > equinox.key
             equinox release --version=${CIRCLE_TAG:1} --platforms="darwin_amd64 linux_amd64 darwin_386 linux_386 windows_amd64 windows_386" --signing-key=equinox.key --app=$EQUINOX_APP_ID --token=$EQUINOX_ACC_TOKEN --channel beta -- -ldflags "-X main.releaseChannel=beta -X main.build=${CIRCLE_SHA1:0:8}" github.com/rainforestapp/rainforest-cli
-            equinox publish --token=$EQUINOX_ACC_TOKEN --app=$EQUINOX_APP_ID --channel dev --version=${CIRCLE_TAG:1}
+            equinox publish --token=$EQUINOX_ACC_TOKEN --app=$EQUINOX_APP_ID --channel dev --release=${CIRCLE_TAG:1}
             rm -f equinox.key
 
   deploy_dev:


### PR DESCRIPTION
The docs call `equinox publish` [with the `--version` flag](https://equinox.io/docs#promote-release), but the release tool itself seems to expect a `--release` flag instead:
```
~$ equinox publish --help
NAME:
   equinox publish - publish a release to a channel

USAGE:
   equinox publish [command options] [arguments...]

OPTIONS:
   --app value         publish release for this equinox app
   --channel value     publish release to this channel
   --config value      path to configuration file
   --release value     release to publish
   --token value       equinox.io credential token
   --log value         path to log file, 'stdout', 'stderr' or 'false' (default: "false")
   --log-level value   logging level (default: "info")
   --log-format value  log record format: 'term', 'logfmt', 'json' (default: "term")
```

Which is what the Equinox GitHub action [is doing](https://github.com/equinox-io/release/blob/9d67e37c1db620e425421bfc01acf0588c218f64/src/main.ts#L81-L98):
```typescript
'publish',
`--release=${version}`,
```
vs.
```typescript
'release',
`--version=${version}`,
```