### PR TITLE
RF-19424 Preserve draft state

### DIFF
--- a/rainforest/rfml.go
+++ b/rainforest/rfml.go
@@ -285,8 +285,8 @@ func (r *RFMLWriter) WriteRFMLTest(test *RFTest) error {
 		}
 	}
 
-	if test.State == "disabled" {
-		_, err = writer.WriteString("# state: disabled\n")
+	if test.State != "" && test.State != "enabled" {
+		_, err = writer.WriteString(fmt.Sprintf("# state: %s\n", test.State))
 		if err != nil {
 			return err
 		}

--- a/rainforest/rfml_test.go
+++ b/rainforest/rfml_test.go
@@ -503,12 +503,30 @@ func TestWriteRFMLTest(t *testing.T) {
 		t.Logf("Output:\n%v", output)
 	}
 
-	// Test state omitted
+	// Test enabled state omitted
 	buffer.Reset()
 	test.State = "enabled"
 	output = getOutput()
 	if strings.Contains(output, "state") {
 		t.Error("Test state field not expected to appear")
+		t.Logf("Output:\n%v", output)
+	}
+
+	// Test empty state omitted (rainforest new)
+	buffer.Reset()
+	test.State = ""
+	output = getOutput()
+	if strings.Contains(output, "state") {
+		t.Error("Test state field not expected to appear")
+		t.Logf("Output:\n%v", output)
+	}
+
+	// Test draft state included
+	buffer.Reset()
+	test.State = "draft"
+	output = getOutput()
+	if !strings.Contains(output, "state") {
+		t.Error("Test state expected to appear")
 		t.Logf("Output:\n%v", output)
 	}
 


### PR DESCRIPTION
I've cherry-picked commits from Forked PR https://github.com/rainforestapp/rainforest-cli/pull/390 created by @mikesbrown
because CircleCI does not run on Forked PRs for Security reasons.

---

Fixes #389

This seemed straightforward enough that I could submit a PR to fix, should you desire it. I've written a few tests to ensure desired behavior. Note that this should:

Preserve behavior in which enabled state is not explicitly written with rainforest download
Preserve behavior in which rainforest new does not write out any state
Write out any new state added to the system in the future