### PR TITLE
[RF-20430] Add --max-reruns flag to the run command

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ Popular command line options are:
 - `--bg` - creates a run in the background and rainforest-cli exits immediately after. Do not use if you want rainforest-cli to track your run and exit with an error code upon run failure (ie: using Rainforest in your CI environment).
 - `--crowd [default|automation|automation_and_crowd|on_premise_crowd]` - select automation or your crowd of testers (for clients with on premise testers). For more information, contact us at help@rainforestqa.com.
 - `--wait RUN_ID` - wait for an existing run to finish instead of starting a new one, and exit with a non-0 code if the run fails. rainforest-cli will exit immediately if the run is already complete.
-- `--fail-fast` - fail the build as soon as the first failed result comes in. If you don't pass this it will wait until 100% of the run is done. Has no effect with `--bg`.
+- `--fail-fast` - return an error as soon as the first failed result comes in (the run always proceeds until completion, but the CLI will return an error code early). If you don't use it, it will wait until 100% of the run is done. Has no effect with `--bg` and cannot be used together with `--max-reruns`.
 - `--custom-url` - use a custom url for this run to use an ad-hoc QA environment on all tests. You will need to specify a `site_id` too for this to work. Note that we will be creating a new environment for your account for this particular run.
 - `--git-trigger` - only trigger a run when the last commit (for a git repo in the current working directory) has contains `@rainforest` and a list of one or more tags. E.g. "Fix checkout process. @rainforest #checkout" would trigger a run for everything tagged `checkout`. This over-rides `--tag` and any tests specified. If no `@rainforest` is detected it will exit 0.
 - `--description "CI automatic run"` - add an arbitrary description for the run.
@@ -343,6 +343,7 @@ api to construct a junit report.  This is useful to track tests in CI such as Je
 - `--import-variable-csv-file /path/to/csv/file.csv` - Use with `run` and `--import-variable-name` to upload new tabular variable values before your run to specify the path to your CSV file.
 - `--import-variable-name NAME` - Use with `run` and `--import-variable-csv-file` to upload new tabular variable values before your run to specify the name of your tabular variable. You may also use this with the `csv-upload` command to update your variable without starting a run.
 - `--single-use` - Use with `run` or `csv-upload` to flag your variable upload as `single-use`. See `--import-variable-csv-file` and `--import-variable-name` options as well.
+- `--max-reruns` - If set to a value > 0 and a test fails, the CLI will re-run failed tests a number of times before reporting failure. If `--junit-file <filename>` is also used, the JUnit reports of reruns will be saved under `<filename>.1`, `<filename>.2` etc. Cannot be used together with `--fail-fast`.
 
 ## Support
 

--- a/README.md
+++ b/README.md
@@ -327,7 +327,7 @@ Popular command line options are:
 - `--run-group ID` - run/filter based on a run group. When used with `run`, this trigger a run from the run group; it can't be used in conjunction with other test filters.
 - `--environment-id` - run your tests using this environment. Otherwise it will use your default environment
 - `--conflict OPTION` - use the `abort` option to abort any runs in progress in the same environment as your new run. use the `abort-all` option to abort all runs in progress.
-- `--bg` - creates a run in the background and rainforest-cli exits immediately after. Do not use if you want rainforest-cli to track your run and exit with an error code upon run failure (ie: using Rainforest in your CI environment).
+- `--bg` - creates a run in the background and rainforest-cli exits immediately after. Do not use if you want rainforest-cli to track your run and exit with an error code upon run failure (ie: using Rainforest in your CI environment). Cannot be used together with `--max-reruns`.
 - `--crowd [default|automation|automation_and_crowd|on_premise_crowd]` - select automation or your crowd of testers (for clients with on premise testers). For more information, contact us at help@rainforestqa.com.
 - `--wait RUN_ID` - wait for an existing run to finish instead of starting a new one, and exit with a non-0 code if the run fails. rainforest-cli will exit immediately if the run is already complete.
 - `--fail-fast` - return an error as soon as the first failed result comes in (the run always proceeds until completion, but the CLI will return an error code early). If you don't use it, it will wait until 100% of the run is done. Has no effect with `--bg` and cannot be used together with `--max-reruns`.

--- a/rainforest-cli.go
+++ b/rainforest-cli.go
@@ -54,9 +54,15 @@ var (
 // cli.Context, the other is fakeCLIContext which is used for testing.
 type cliContext interface {
 	String(flag string) (val string)
+	GlobalString(flag string) (val string)
 	StringSlice(flag string) (vals []string)
+	GlobalStringSlice(flag string) (vals []string)
 	Bool(flag string) (val bool)
+	GlobalBool(flag string) (val bool)
 	Int(flag string) (val int)
+	GlobalInt(flag string) (val int)
+	Uint(flag string) (val uint)
+	GlobalUint(flag string) (val uint)
 
 	Args() (args cli.Args)
 }
@@ -246,6 +252,10 @@ func main() {
 					Name:  "wait, reattach",
 					Usage: "monitor existing run with `RUN_ID` instead of starting a new one.",
 				},
+				cli.UintFlag{
+					Name:  "max-reruns",
+					Usage: "Rerun `max-reruns` times before reporting failure.",
+				},
 			},
 		},
 		{
@@ -276,6 +286,14 @@ func main() {
 				cli.StringFlag{
 					Name:  "junit-file",
 					Usage: "Create a JUnit XML report `FILE` with the specified name. Must be run in foreground mode.",
+				},
+				cli.UintFlag{
+					Name:  "max-reruns",
+					Usage: "Rerun `max-reruns` times before reporting failure.",
+				},
+				cli.UintFlag{
+					Name:  "rerun-attempt",
+					Usage: "Which rerun attempt this is.",
 				},
 			},
 		},

--- a/rainforest-cli_test.go
+++ b/rainforest-cli_test.go
@@ -127,6 +127,10 @@ func (f fakeContext) String(s string) string {
 	return ""
 }
 
+func (f fakeContext) GlobalString(s string) string {
+	return f.String(s)
+}
+
 func (f fakeContext) StringSlice(s string) []string {
 	val, ok := f.mappings[s].([]string)
 
@@ -134,6 +138,10 @@ func (f fakeContext) StringSlice(s string) []string {
 		return val
 	}
 	return []string{}
+}
+
+func (f fakeContext) GlobalStringSlice(s string) []string {
+	return f.StringSlice(s)
 }
 
 func (f fakeContext) Bool(s string) bool {
@@ -145,6 +153,10 @@ func (f fakeContext) Bool(s string) bool {
 	return false
 }
 
+func (f fakeContext) GlobalBool(s string) bool {
+	return f.Bool(s)
+}
+
 func (f fakeContext) Int(s string) int {
 	val, ok := f.mappings[s].(int)
 
@@ -152,6 +164,23 @@ func (f fakeContext) Int(s string) int {
 		return val
 	}
 	return 0
+}
+
+func (f fakeContext) GlobalInt(s string) int {
+	return f.GlobalInt(s)
+}
+
+func (f fakeContext) Uint(s string) uint {
+	val, ok := f.mappings[s].(uint)
+
+	if ok {
+		return val
+	}
+	return 0
+}
+
+func (f fakeContext) GlobalUint(s string) uint {
+	return f.GlobalUint(s)
 }
 
 func (f fakeContext) Args() cli.Args {

--- a/reporter_test.go
+++ b/reporter_test.go
@@ -121,6 +121,56 @@ func TestReporterCreateReport(t *testing.T) {
 	}
 }
 
+func TestAugmentJunitFileName(t *testing.T) {
+	testCases := []struct {
+		OriginalName string
+		RerunAttempt uint
+		Want         string
+	}{
+		{
+			OriginalName: "output",
+			RerunAttempt: 1,
+			Want:         "output.1",
+		},
+		{
+			OriginalName: "output.xml",
+			RerunAttempt: 1,
+			Want:         "output.xml.1",
+		},
+		{
+			OriginalName: "output.xml",
+			RerunAttempt: 2,
+			Want:         "output.xml.2",
+		},
+		{
+			OriginalName: "output.xml.1",
+			RerunAttempt: 3,
+			Want:         "output.xml.1.3",
+		},
+		{
+			OriginalName: "some.output.xml.1.2.3",
+			RerunAttempt: 2,
+			Want:         "some.output.xml.1.2.3.2",
+		},
+		{
+			OriginalName: "output.html",
+			RerunAttempt: 1,
+			Want:         "output.html.1",
+		},
+		{
+			OriginalName: "output.1",
+			RerunAttempt: 2,
+			Want:         "output.1.2",
+		},
+	}
+	for _, testCase := range testCases {
+		got := augmentJunitFileName(testCase.OriginalName, testCase.RerunAttempt)
+		if got != testCase.Want {
+			t.Errorf("Wrong name, wanted '%v', got '%v'", testCase.Want, got)
+		}
+	}
+}
+
 type fakeReporterAPI struct {
 	RunMappings map[int][]rainforest.RunTestDetails
 }

--- a/runner.go
+++ b/runner.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/rainforestapp/rainforest-cli/rainforest"
@@ -49,6 +50,17 @@ func (r *runner) startRun(c cliContext) error {
 			return cli.NewExitError(err.Error(), 1)
 		}
 		return monitorRunStatus(c, runID)
+	}
+
+	// Validate that --fail-fast and --max-reruns are not used together
+	failFast := c.Bool("fail-fast")
+	maxReruns := c.Uint("max-reruns")
+	if failFast && (maxReruns > 0) {
+		return cli.NewExitError(
+			"You can't use --fail-fast when --max-reruns is greater than 0. "+
+				"For the CLI to rerun on failure, it has to wait until completion.",
+			1,
+		)
 	}
 
 	var localTests []*rainforest.RFTest
@@ -242,14 +254,25 @@ func monitorRunStatus(c cliContext, runID int) error {
 		log.Print(msg)
 
 		if done {
-			if status.FrontendURL != "" {
-				log.Printf("The detailed results are available at %v\n", status.FrontendURL)
-			}
-
 			postRunJUnitReport(c, runID)
 
 			if status.Result != "passed" {
-				return cli.NewExitError("", 1)
+				rerunAttempt := c.Uint("rerun-attempt")
+				remainingReruns := c.Uint("max-reruns") - rerunAttempt
+				if remainingReruns > 0 {
+					cmd, _ := buildRerunArgs(c, runID)
+					log.Printf("Rerunning %v, attempt %v", runID, rerunAttempt+1)
+					exec_err := syscall.Exec("rainforest-cli", cmd, []string{})
+					if exec_err != nil {
+						return cli.NewExitError(exec_err.Error(), 1)
+					}
+				} else {
+					return cli.NewExitError("", 1)
+				}
+			}
+
+			if status.FrontendURL != "" {
+				log.Printf("The detailed results are available at %v\n", status.FrontendURL)
 			}
 
 			return nil
@@ -271,6 +294,34 @@ func monitorRunStatus(c cliContext, runID int) error {
 
 		time.Sleep(runStatusPollInterval)
 	}
+}
+
+func buildRerunArgs(c cliContext, runID int) ([]string, error) {
+	maxReruns := c.Uint("max-reruns")
+	rerunAttempt := c.Uint("rerun-attempt")
+
+	cmd := []string{
+		"rainforest-cli",
+		"rerun", strconv.Itoa(runID),
+		"--max-reruns", fmt.Sprint(maxReruns),
+		"--rerun-attempt", fmt.Sprint(rerunAttempt + 1),
+		"--skip-update", // skip auto-updates for reruns
+	}
+
+	if token := c.GlobalString("token"); len(token) > 0 {
+		cmd = append(cmd, "--token", token)
+	}
+	if conflict := c.String("conflict"); len(conflict) > 0 {
+		cmd = append(cmd, "--conflict", conflict)
+	}
+	if background := c.Bool("background"); background {
+		cmd = append(cmd, "--background")
+	}
+	if junitFile := c.String("junit-file"); len(junitFile) > 0 {
+		cmd = append(cmd, "--junit-file", junitFile)
+	}
+
+	return cmd, nil
 }
 
 func getRunStatus(failFast bool, runID int, client runnerAPI) (*rainforest.RunStatus, string, bool, error) {

--- a/runner.go
+++ b/runner.go
@@ -52,12 +52,13 @@ func (r *runner) startRun(c cliContext) error {
 		return monitorRunStatus(c, runID)
 	}
 
-	// Validate that --fail-fast and --max-reruns are not used together
+	// verify --max-reruns is not used with either --fail-fast or --background
 	failFast := c.Bool("fail-fast")
+	background := c.Bool("background")
 	maxReruns := c.Uint("max-reruns")
-	if failFast && (maxReruns > 0) {
+	if (maxReruns > 0) && (failFast || background) {
 		return cli.NewExitError(
-			"You can't use --fail-fast when --max-reruns is greater than 0. "+
+			"You can't use --fail-fast or --background when --max-reruns is greater than 0. "+
 				"For the CLI to rerun on failure, it has to wait until completion.",
 			1,
 		)
@@ -313,9 +314,6 @@ func buildRerunArgs(c cliContext, runID int) ([]string, error) {
 	}
 	if conflict := c.String("conflict"); len(conflict) > 0 {
 		cmd = append(cmd, "--conflict", conflict)
-	}
-	if background := c.Bool("background"); background {
-		cmd = append(cmd, "--background")
 	}
 	if junitFile := c.String("junit-file"); len(junitFile) > 0 {
 		cmd = append(cmd, "--junit-file", junitFile)

--- a/runner_test.go
+++ b/runner_test.go
@@ -434,3 +434,55 @@ func TestStartLocalRun(t *testing.T) {
 		}
 	}
 }
+
+func TestBuildRerunArgs(t *testing.T) {
+	testCases := []struct {
+		Mappings map[string]interface{}
+		Args     cli.Args
+		RunID    int
+		WantArgs []string
+	}{
+		{
+			Mappings: map[string]interface{}{
+				"junit-file":  "result.xml",
+				"max-reruns":  uint(2),
+				"skip-update": true,
+			},
+			Args:  cli.Args{},
+			RunID: 123,
+			WantArgs: []string{
+				"rainforest-cli",
+				"rerun",
+				"123",
+				"--max-reruns", "2",
+				"--rerun-attempt", "1",
+				"--skip-update",
+				"--junit-file", "result.xml",
+			},
+		},
+		{
+			Mappings: map[string]interface{}{
+				"max-reruns": uint(1),
+				"token":      "deadbeef",
+			},
+			Args:  cli.Args{},
+			RunID: 123,
+			WantArgs: []string{
+				"rainforest-cli",
+				"rerun",
+				"123",
+				"--max-reruns", "1",
+				"--rerun-attempt", "1",
+				"--skip-update",
+				"--token", "deadbeef",
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		c := newFakeContext(testCase.Mappings, testCase.Args)
+		gotArgs, _ := buildRerunArgs(c, testCase.RunID)
+		if !reflect.DeepEqual(gotArgs, testCase.WantArgs) {
+			t.Errorf("\nWanted %v\n   got %v", testCase.WantArgs, gotArgs)
+		}
+	}
+}


### PR DESCRIPTION
This should address #396. When retrying, the console output looks like this:

```
2020/12/17 16:26:38 Run 674699 is in_progress and is 0% complete
2020/12/17 16:26:44 Run 674699 is in_progress and is 50% complete
2020/12/17 16:26:49 Run 674699 is in_progress and is 50% complete
2020/12/17 16:26:55 Run 674699 is in_progress and is 50% complete
2020/12/17 16:27:00 Run 674699 is in_progress and is 50% complete
2020/12/17 16:27:05 Run 674699 is in_progress and is 50% complete
2020/12/17 16:27:11 Run 674699 is in_progress and is 50% complete
2020/12/17 16:27:16 Run 674699 is now complete and has failed
2020/12/17 16:27:16 Creating JUnit report for run #674699: output.xml
2020/12/17 16:27:16 Fetching details for run #674699
2020/12/17 16:27:16 Fetching information for failed test #273949
2020/12/17 16:27:17 JUnit report successfully written to /home/mgryka/dev/rainforest/rainforest-cli/output.xml
2020/12/17 16:27:17 Retrying run 674699, attempt 1
2020/12/17 16:27:18 Run 674700 has been created.
2020/12/17 16:27:18 Run 674700 is queued and is 0% complete
2020/12/17 16:27:24 Run 674700 is in_progress and is 0% complete
2020/12/17 16:27:30 Run 674700 is in_progress and is 0% complete
2020/12/17 16:27:35 Run 674700 is in_progress and is 0% complete
2020/12/17 16:27:40 Run 674700 is in_progress and is 0% complete
2020/12/17 16:27:46 Run 674700 is in_progress and is 0% complete

```