### PR TITLE
RF-20670 Locate the rainforest binary from the executable

### DIFF
--- a/runner.go
+++ b/runner.go
@@ -262,8 +262,13 @@ func monitorRunStatus(c cliContext, runID int) error {
 				remainingReruns := c.Uint("max-reruns") - rerunAttempt
 				if remainingReruns > 0 {
 					cmd, _ := buildRerunArgs(c, runID)
+					path, err := os.Executable()
+					if err != nil {
+						return cli.NewExitError(err.Error(), 1)
+					}
+
 					log.Printf("Rerunning %v, attempt %v", runID, rerunAttempt+1)
-					exec_err := syscall.Exec("rainforest-cli", cmd, []string{})
+					exec_err := syscall.Exec(path, cmd, []string{})
 					if exec_err != nil {
 						return cli.NewExitError(exec_err.Error(), 1)
 					}


### PR DESCRIPTION
Use `os.Executable()` (golang >=1.8) to get the path to the RF CLI when
re-execing it for reruns. This can fail if the file is moved, but it
doesn't seem to be possible to exec based on a FD reliably, so this is
probably good enough.