### PR TITLE
RF-21068 Update custom-url documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,7 +331,7 @@ Popular command line options are:
 - `--crowd [default|automation|automation_and_crowd|on_premise_crowd]` - select automation or your crowd of testers (for clients with on premise testers). For more information, contact us at help@rainforestqa.com.
 - `--wait RUN_ID` - wait for an existing run to finish instead of starting a new one, and exit with a non-0 code if the run fails. rainforest-cli will exit immediately if the run is already complete.
 - `--fail-fast` - return an error as soon as the first failed result comes in (the run always proceeds until completion, but the CLI will return an error code early). If you don't use it, it will wait until 100% of the run is done. Has no effect with `--bg` and cannot be used together with `--max-reruns`.
-- `--custom-url` - use a custom url for this run to use an ad-hoc QA environment on all tests. You will need to specify a `site_id` too for this to work. Note that we will be creating a new environment for your account for this particular run.
+- `--custom-url` - specify the URL for the run to use when testing against an ephemeral QA environment. This will create a new environment for the run.
 - `--git-trigger` - only trigger a run when the last commit (for a git repo in the current working directory) has contains `@rainforest` and a list of one or more tags. E.g. "Fix checkout process. @rainforest #checkout" would trigger a run for everything tagged `checkout`. This over-rides `--tag` and any tests specified. If no `@rainforest` is detected it will exit 0.
 - `--description "CI automatic run"` - add an arbitrary description for the run.
 - `--release "1a2b3d"` - add an ID to associate the run with a release. Commonly used values are commit SHAs, build IDs, branch names, etc.

--- a/rainforest-cli.go
+++ b/rainforest-cli.go
@@ -211,8 +211,8 @@ func main() {
 				},
 				cli.StringFlag{
 					Name: "custom-url",
-					Usage: "use a custom `URL` for this run. Example use case: an ad-hoc QA environment with Fourchette. " +
-						"You will need to specify a site_id too for this to work.",
+					Usage: "specify the URL for the run to use when testing against an ephemeral QA environment. " +
+						"This will create a new environment for the run.",
 				},
 				cli.BoolFlag{
 					Name: "git-trigger",


### PR DESCRIPTION
We don't require the site_id to be specified when setting the
custom_url. Update the documentation to reflect this.

See runner.go#L390-L415 for the code that uses custom-url to see the
lack of dependencies.