### PR TITLE
RF-22011 report urls for failures

### DIFF
--- a/reporter.go
+++ b/reporter.go
@@ -179,7 +179,7 @@ func testURL(runID int, testID int) string {
 	return u.String()
 }
 
-func createJUnitReportSchema(runDetails *rainforest.RunDetails, api reporterAPI) (*jUnitReportSchema, error) {
+func createJUnitReportSchema(runDetails *rainforest.RunDetails, apiReporter reporterAPI) (*jUnitReportSchema, error) {
 	type processedTestCase struct {
 		TestCase jUnitTestReportSchema
 		Error    error
@@ -202,7 +202,7 @@ func createJUnitReportSchema(runDetails *rainforest.RunDetails, api reporterAPI)
 
 			if test.Result == "failed" {
 				log.Printf("Fetching information for failed test #" + strconv.Itoa(test.ID))
-				testDetails, err := api.GetRunTestDetails(runDetails.ID, test.ID)
+				testDetails, err := apiReporter.GetRunTestDetails(runDetails.ID, test.ID)
 
 				if err != nil {
 					processedTestChan <- processedTestCase{TestCase: jUnitTestReportSchema{}, Error: err}

--- a/reporter_test.go
+++ b/reporter_test.go
@@ -211,6 +211,7 @@ func TestCreateJUnitReportSchema(t *testing.T) {
 	totalNoResultTests := 0
 	totalFailedTests := 0
 	stateName := "complete"
+	api = rainforest.NewClient("fake_token", false)
 
 	runDetails := rainforest.RunDetails{
 		ID:                 123,
@@ -240,9 +241,9 @@ func TestCreateJUnitReportSchema(t *testing.T) {
 	}
 
 	// Dummy API - should not be used when there are no failed tests
-	api := newFakeReporterAPI(-1, []rainforest.RunTestDetails{})
+	reporterAPI := newFakeReporterAPI(-1, []rainforest.RunTestDetails{})
 
-	schema, err := createJUnitReportSchema(&runDetails, api)
+	schema, err := createJUnitReportSchema(&runDetails, reporterAPI)
 	if err != nil {
 		t.Errorf("Unexpected error returned by createJunitTestReportSchema: %v", err)
 	}
@@ -271,7 +272,7 @@ func TestCreateJUnitReportSchema(t *testing.T) {
 
 	// Run has no description
 	runDetails.Description = ""
-	schema, err = createJUnitReportSchema(&runDetails, api)
+	schema, err = createJUnitReportSchema(&runDetails, reporterAPI)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
@@ -285,7 +286,6 @@ func TestCreateJUnitReportSchema(t *testing.T) {
 
 	// With automation failures
 	failedBrowser := "chrome_1440_900"
-	failedNote := ""
 
 	runDetails.TotalFailedTests = 1
 
@@ -339,7 +339,7 @@ func TestCreateJUnitReportSchema(t *testing.T) {
 		},
 	}
 
-	api = newFakeReporterAPI(runDetails.ID, apiTests)
+	reporterAPI = newFakeReporterAPI(runDetails.ID, apiTests)
 
 	expectedSchema.Failures = 1
 	expectedSchema.TestCases = []jUnitTestReportSchema{
@@ -350,7 +350,7 @@ func TestCreateJUnitReportSchema(t *testing.T) {
 			Failures: []jUnitTestReportFailure{
 				{
 					Type:    failedBrowser,
-					Message: "",
+					Message: "https://app.rainforestqa.com/runs/123/tests/999888",
 				},
 			},
 		},
@@ -358,7 +358,7 @@ func TestCreateJUnitReportSchema(t *testing.T) {
 
 	var out bytes.Buffer
 	log.SetOutput(&out)
-	schema, err = createJUnitReportSchema(&runDetails, api)
+	schema, err = createJUnitReportSchema(&runDetails, reporterAPI)
 	log.SetOutput(os.Stdout)
 
 	if err != nil {
@@ -373,7 +373,7 @@ func TestCreateJUnitReportSchema(t *testing.T) {
 
 	// With failures
 	failedBrowser = "chrome"
-	failedNote = "This note should appear"
+	failedNote := "This note should appear"
 
 	runDetails.TotalFailedTests = 1
 
@@ -423,7 +423,7 @@ func TestCreateJUnitReportSchema(t *testing.T) {
 		},
 	}
 
-	api = newFakeReporterAPI(runDetails.ID, apiTests)
+	reporterAPI = newFakeReporterAPI(runDetails.ID, apiTests)
 
 	expectedSchema.Failures = 1
 	expectedSchema.TestCases = []jUnitTestReportSchema{
@@ -434,7 +434,7 @@ func TestCreateJUnitReportSchema(t *testing.T) {
 			Failures: []jUnitTestReportFailure{
 				{
 					Type:    failedBrowser,
-					Message: failedNote,
+					Message: "https://app.rainforestqa.com/runs/123/tests/999888 - " + failedNote,
 				},
 			},
 		},
@@ -442,7 +442,7 @@ func TestCreateJUnitReportSchema(t *testing.T) {
 
 	out = bytes.Buffer{}
 	log.SetOutput(&out)
-	schema, err = createJUnitReportSchema(&runDetails, api)
+	schema, err = createJUnitReportSchema(&runDetails, reporterAPI)
 	log.SetOutput(os.Stdout)
 
 	if err != nil {
@@ -494,7 +494,7 @@ func TestCreateJUnitReportSchema(t *testing.T) {
 		},
 	}
 
-	api = newFakeReporterAPI(runDetails.ID, apiTests)
+	reporterAPI = newFakeReporterAPI(runDetails.ID, apiTests)
 
 	expectedSchema.TestCases = []jUnitTestReportSchema{
 		{
@@ -504,14 +504,14 @@ func TestCreateJUnitReportSchema(t *testing.T) {
 			Failures: []jUnitTestReportFailure{
 				{
 					Type:    failedBrowser,
-					Message: fmt.Sprintf("%v: %v", commentReason, comment),
+					Message: fmt.Sprintf("https://app.rainforestqa.com/runs/123/tests/999888 - %v: %v", commentReason, comment),
 				},
 			},
 		},
 	}
 
 	log.SetOutput(&out)
-	schema, err = createJUnitReportSchema(&runDetails, api)
+	schema, err = createJUnitReportSchema(&runDetails, reporterAPI)
 	log.SetOutput(os.Stdout)
 
 	if err != nil {


### PR DESCRIPTION
Provide URLs to the app so it's easier to hop from the CircleCI display of failed results to the failure and diagnose what happened.

This generates junit XML that looks like:
```
<testsuite id="761688" name="Rainforest - master 188298 2021-07-20T13:50:15Z" tests="1" errors="0" failures="1" time="734.472">
  <testcase id="204138" name="Embed Test" time="580">
    <failure type="chrome_1440_900" message="https://app.rainforestqa.com/runs/761688/tests/204138">/failure>
  </testcase>
</testsuite>
```

which is rendered by Circle like this:
![image](https://user-images.githubusercontent.com/174241/126499656-f49f992c-7fee-4a29-9b47-419ee355d134.png)

You can then hightlight the URL, right-click and select "go to ..." to open the failed test in a new tab. It'd be nicer if Circle gave you an actual clickable link - but I don't know how to get that out of their renderer.