### PR TITLE
[RF-21914] Stop publishing releases to Equinox

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,14 +1,5 @@
 version: 2
 
-steps:
-  - &install_equinox
-    run:
-        name: Install Equinox Release Tool
-        command: |
-          mkdir ~/download
-          cd ~/download && curl -O https://bin.equinox.io/c/mBWdkfai63v/release-tool-stable-linux-amd64.zip
-          sudo unzip ~/download/release-tool-stable-linux-amd64.zip -d /usr/local/bin
-
 defaults: &defaults
   docker:
     - image: circleci/golang:1.12.4-node
@@ -24,45 +15,6 @@ jobs:
       - run:
           name: Run Unit Tests
           command: go test -v -race ./...
-
-  deploy_stable:
-    <<: *defaults
-    steps:
-      - checkout
-      - *install_equinox
-      - run:
-          name: Release to Stable Channel
-          command: |
-            echo -e $EQUINOX_KEY > equinox.key
-            CGO_ENABLED=0 equinox release --version=${CIRCLE_TAG:1} --platforms="darwin_amd64 linux_amd64 darwin_386 linux_386 windows_amd64 windows_386" --signing-key=equinox.key --app=$EQUINOX_APP_ID --token=$EQUINOX_ACC_TOKEN --channel stable -- -ldflags "-X main.releaseChannel=stable -X main.build=${CIRCLE_SHA1:0:8}" github.com/rainforestapp/rainforest-cli
-            equinox publish --token=$EQUINOX_ACC_TOKEN --app=$EQUINOX_APP_ID --channel beta --release=${CIRCLE_TAG:1}
-            equinox publish --token=$EQUINOX_ACC_TOKEN --app=$EQUINOX_APP_ID --channel dev --release=${CIRCLE_TAG:1}
-            rm -f equinox.key
-
-  deploy_beta:
-    <<: *defaults
-    steps:
-      - checkout
-      - *install_equinox
-      - run:
-          name: Release to Beta Channel
-          command: |
-            echo -e $EQUINOX_KEY > equinox.key
-            CGO_ENABLED=0 equinox release --version=${CIRCLE_TAG:1} --platforms="darwin_amd64 linux_amd64 darwin_386 linux_386 windows_amd64 windows_386" --signing-key=equinox.key --app=$EQUINOX_APP_ID --token=$EQUINOX_ACC_TOKEN --channel beta -- -ldflags "-X main.releaseChannel=beta -X main.build=${CIRCLE_SHA1:0:8}" github.com/rainforestapp/rainforest-cli
-            equinox publish --token=$EQUINOX_ACC_TOKEN --app=$EQUINOX_APP_ID --channel dev --release=${CIRCLE_TAG:1}
-            rm -f equinox.key
-
-  deploy_dev:
-    <<: *defaults
-    steps:
-      - checkout
-      - *install_equinox
-      - run:
-          name: Release to Dev Channel
-          command: |
-            echo -e $EQUINOX_KEY > equinox.key
-            CGO_ENABLED=0 equinox release --version=${CIRCLE_SHA1:0:8} --platforms="darwin_amd64 linux_amd64 darwin_386 linux_386 windows_amd64 windows_386" --signing-key=equinox.key --app=$EQUINOX_APP_ID --token=$EQUINOX_ACC_TOKEN --channel dev -- -ldflags "-X main.releaseChannel=dev -X main.build=${CIRCLE_SHA1:0:8}" github.com/rainforestapp/rainforest-cli
-            rm -f equinox.key
 
   release:
     <<: *defaults
@@ -84,32 +36,6 @@ workflows:
   test_and_deploy:
     jobs:
       - test:
-          context:
-            - DockerHub
-      - deploy_dev:
-          requires:
-            - test
-          filters:
-            branches:
-              only: master
-          context:
-            - DockerHub
-      - deploy_beta:
-          filters:
-            # don't execute on branch pushes, only tag pushes
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v[0-9]+(\.[0-9]+)*(\-(alpha|beta)\.[0-9]+)$/
-          context:
-            - DockerHub
-      - deploy_stable:
-          filters:
-            # don't execute on branch pushes, only tag pushes
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v[0-9]+(\.[0-9]+)*$/
           context:
             - DockerHub
       - release:


### PR DESCRIPTION
The plan is to release this a `2.21.1`, and then we'll be able to tell anyone still using `2.20.0` and below that they need to update.