### PR TITLE
Use rainforest rather than rainforest-cli in Docker image as well

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,12 +26,37 @@ commands:
             go version
   go_build:
     description: "go build, and output cli version"
+    parameters:
+      windows:
+        description: Whether this is running on Windows
+        type: boolean
+        default: false
     steps:
       - run:
           name: Build
-          command: |
-            go build
-            ./rainforest-cli -v --skip-update
+          command: go build -o build/rainforest<<# parameters.windows >>.exe<</ parameters.windows >>
+      - when:
+          condition: << parameters.windows >>
+          steps:
+            - run:
+                name: Move executable
+                command: |
+                  Move-Item rainforest rainforest-dir
+                  Move-Item build\./rainforest.exe .
+            - run:
+                name: Show CLI version
+                command: ./rainforest.exe -v --skip-update
+      - unless:
+          condition: << parameters.windows >>
+          steps:
+            - run:
+                name: Move executable
+                command: |
+                  mv rainforest rainforest-dir
+                  mv build/rainforest .
+            - run:
+                name: Show CLI version
+                command: ./rainforest -v --skip-update
 
 jobs:
   validate_goreleaser_config:
@@ -66,7 +91,7 @@ jobs:
       - run:
           name: Start a run that will pass
           command: |
-            ./rainforest-cli --skip-update run --run-group 9502
+            ./rainforest --skip-update run --run-group 9502
 
   integration_mac_pass_junit:
     <<: *mac
@@ -77,7 +102,7 @@ jobs:
       - run:
           name: Start a run that will pass, with junit
           command: |
-            ./rainforest-cli --skip-update run --run-group 9502 --junit-file junit-pass.xml
+            ./rainforest --skip-update run --run-group 9502 --junit-file junit-pass.xml
       - store_test_results:
           path: junit-pass.xml
 
@@ -91,7 +116,7 @@ jobs:
           name: Start a run that will fail
           command: |
             set +e
-            ./rainforest-cli --skip-update run --run-group 9503
+            ./rainforest --skip-update run --run-group 9503
             if [[ $? != 0 ]]; then
               echo "TESTING ::: Got the expected non-zero exit code. ✅"
               echo 0
@@ -110,7 +135,7 @@ jobs:
           name: Start a run that will fail, with junit
           command: |
             set +e
-            ./rainforest-cli --skip-update run --run-group 9503 --junit-file junit-fail.xml
+            ./rainforest --skip-update run --run-group 9503 --junit-file junit-fail.xml
             if [[ $? != 0 ]]; then
               echo "TESTING ::: Got the expected non-zero exit code. ✅"
               echo 0
@@ -129,7 +154,7 @@ jobs:
       - run:
           name: Start a run that will pass
           command: |
-            ./rainforest-cli --skip-update run --run-group 9502
+            ./rainforest --skip-update run --run-group 9502
 
   integration_linux_pass_junit:
     <<: *defaults
@@ -139,7 +164,7 @@ jobs:
       - run:
           name: Start a run that will pass, with junit
           command: |
-            ./rainforest-cli --skip-update run --run-group 9502 --junit-file junit-pass.xml
+            ./rainforest --skip-update run --run-group 9502 --junit-file junit-pass.xml
       - store_test_results:
           path: junit-pass.xml
 
@@ -152,7 +177,7 @@ jobs:
           name: Start a run that will fail
           command: |
             set +e
-            ./rainforest-cli --skip-update run --run-group 9503
+            ./rainforest --skip-update run --run-group 9503
             if [[ $? != 0 ]]; then
               echo "TESTING ::: Got the expected non-zero exit code. ✅"
               echo 0
@@ -170,7 +195,7 @@ jobs:
           name: Start a run that will fail, with junit
           command: |
             set +e
-            ./rainforest-cli --skip-update run --run-group 9503 --junit-file junit-fail.xml
+            ./rainforest --skip-update run --run-group 9503 --junit-file junit-fail.xml
             if [[ $? != 0 ]]; then
               echo "TESTING ::: Got the expected non-zero exit code. ✅"
               exit 0
@@ -185,25 +210,23 @@ jobs:
     <<: *windows
     steps:
       - checkout
+      - go_build:
+          windows: true
       - run:
-          name: "Build, and run rainforest"
-          shell: powershell.exe
+          name: Run rainforest
           command: |
-            go build
-            ./rainforest-cli.exe -v --skip-update
-            ./rainforest-cli.exe --skip-update run --run-group 9502
+            ./rainforest.exe --skip-update run --run-group 9502
 
   integration_windows_pass_junit:
     <<: *windows
     steps:
       - checkout
+      - go_build:
+          windows: true
       - run:
-          name: "Build, and run rainforest with junit output"
-          shell: powershell.exe
+          name: Run rainforest with junit output
           command: |
-            go build
-            ./rainforest-cli.exe -v --skip-update
-            ./rainforest-cli.exe --skip-update run --run-group 9502 --junit-file junit-pass.xml
+            ./rainforest.exe --skip-update run --run-group 9502 --junit-file junit-pass.xml
       - store_test_results:
           path: junit-pass.xml
 
@@ -211,13 +234,12 @@ jobs:
     <<: *windows
     steps:
       - checkout
+      - go_build:
+          windows: true
       - run:
-          name: "Build, and run rainforest"
-          shell: powershell.exe
+          name: Run rainforest
           command: |
-            go build
-            ./rainforest-cli.exe -v --skip-update
-            ./rainforest-cli.exe --skip-update run --run-group 9503
+            ./rainforest.exe --skip-update run --run-group 9503
             if ($LastExitCode -gt 0) {
               echo "TESTING ::: Got the expected non-zero exit code."
               exit 0
@@ -230,13 +252,12 @@ jobs:
     <<: *windows
     steps:
       - checkout
+      - go_build:
+          windows: true
       - run:
-          name: "Build, and run rainforest with junit output"
-          shell: powershell.exe
+          name: Run rainforest with junit output
           command: |
-            go build
-            ./rainforest-cli.exe -v --skip-update
-            ./rainforest-cli.exe --skip-update run --run-group 9503 --junit-file junit-fail.xml
+            ./rainforest.exe --skip-update run --run-group 9503 --junit-file junit-fail.xml
             if ($LastExitCode -gt 0) {
               echo "TESTING ::: Got the expected non-zero exit code."
               exit 0

--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,5 @@ testing
 rainforest-cli
 rainforest-cli.exe
 /vendor
+build/
 dist/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Rainforest CLI Changelog
 
+## 2.23.0 - 2021-09-30
+- Rename the CLI executable to `rainforest` in our `gcr.io/rf-public-images/rainforest-cli` Docker image
+  - (deec4ac3131e86d3172441ea84f9e4d62829cf59, @magni-)
 ## 2.22.3 - 2021-09-29
 - Make the CLI error instead of panic if you provide an empty token
   - (e5d48917733568f1a64316376808797d0a414b54, @jbarber)

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,9 @@ FROM golang:1.12.4-alpine3.9 AS builder
 RUN apk add --no-cache git
 WORKDIR /build
 COPY . .
-RUN go build -ldflags "-X main.build=docker"
+RUN go build -ldflags "-X main.build=docker" -o build/rainforest
 
 FROM alpine:3.9
 RUN apk add --no-cache ca-certificates
-COPY --from=builder /build/rainforest-cli /usr/local/bin/rainforest-cli
-ENTRYPOINT ["rainforest-cli", "--skip-update"]
+COPY --from=builder /build/build/rainforest /usr/local/bin/rainforest
+ENTRYPOINT ["rainforest", "--skip-update"]

--- a/rainforest-cli.go
+++ b/rainforest-cli.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	// Version of the app in SemVer
-	version = "2.22.3"
+	version = "2.23.0"
 	// This is the default spec folder for RFML tests
 	defaultSpecFolder = "./spec/rainforest"
 )


### PR DESCRIPTION
Keeps things consistent whether you're installing from GH releases or using our Docker image.