### PR TITLE
Fix documentation for installing latest CLI on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The CLI will check for updates and automatically update itself on every use unle
 You can download the latest (Linux) `rainforest-cli` binary with the following command (requires `curl`, `jq` and `tar`):
 
 ```bash
-curl -sL $(curl -s https://api.github.com/repos/rainforestapp/rainforest-cli/releases/latest | jq -r '.assets[].browser_download_url | select(test("linux-amd64.tar.gz"))') | tar zxf - rainforest-cli
+curl -sL $(curl -s https://api.github.com/repos/rainforestapp/rainforest-cli/releases/latest | jq -r '.assets[].browser_download_url | select(test("linux-amd64.tar.gz"))') | tar zxf - rainforest
 ```
 
 ### Migrating from our old CLI


### PR DESCRIPTION
This was changed in https://github.com/rainforestapp/rainforest-cli/pull/431.

Fixes #436
