### PR TITLE
[RF-23055] Add `--save-run-id` flag to `run` and `rerun` commands

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,17 +1,21 @@
 version: 2.1
 orbs:
-  win: circleci/windows@2.2.0
+  win: circleci/windows@2.3.0
 
-defaults: &defaults
-  docker:
-    - image: cimg/go:1.17.1-node
-windows: &windows
-  executor:
-    name: win/default
-    shell: powershell.exe
-mac: &mac
-  macos:
-    xcode: 11.3.0
+windows-param: &windows-param
+  windows:
+    description: Whether this is running on Windows
+    type: boolean
+    default: false
+
+executors:
+  mac:
+    macos:
+      xcode: 11.3.0
+  linux:
+    docker:
+      - image: cimg/go:1.17.1-node
+  windows: win/default
 
 commands:
   install_go_darwin:
@@ -27,10 +31,7 @@ commands:
   go_build:
     description: "go build, and output cli version"
     parameters:
-      windows:
-        description: Whether this is running on Windows
-        type: boolean
-        default: false
+      <<: *windows-param
     steps:
       - run:
           name: Build
@@ -58,9 +59,103 @@ commands:
                 name: Show CLI version
                 command: ./rainforest -v --skip-update
 
+  pass:
+    parameters:
+      <<: *windows-param
+    description: Start a run that will pass
+    steps:
+      - run:
+          name: Start a run that will pass
+          command: |
+            ./rainforest<<# parameters.windows >>.exe<</ parameters.windows >> --skip-update run --run-group 9502
+
+  pass_junit:
+    parameters:
+      <<: *windows-param
+    description: Start a run that will pass, with junit
+    steps:
+      - run:
+          name: Start a run that will pass, with junit
+          command: |
+            ./rainforest<<# parameters.windows >>.exe<</ parameters.windows >> --skip-update run --run-group 9502 --junit-file junit-pass.xml
+      - store_test_results:
+          path: junit-pass.xml
+
+  fail:
+    parameters:
+      <<: *windows-param
+    description: Start a run that will fail
+    steps:
+      - when:
+          condition: << parameters.windows >>
+          steps:
+            - run:
+                name: Start a run that will fail
+                command: |
+                  ./rainforest.exe --skip-update run --run-group 9503
+                  if ($LastExitCode -gt 0) {
+                    echo "TESTING ::: Got the expected non-zero exit code."
+                    exit 0
+                  } else {
+                    echo "TESTING ::: Got UNEXPECTED zero exit code."
+                    exit 1
+                  }
+      - unless:
+          condition: << parameters.windows >>
+          steps:
+            - run:
+                name: Start a run that will fail
+                command: |
+                  set +e
+                  ./rainforest --skip-update run --run-group 9503
+                  if [[ $? != 0 ]]; then
+                    echo "TESTING ::: Got the expected non-zero exit code. ✅"
+                    echo 0
+                  else
+                    echo "TESTING ::: Got UNEXPECTED zero exit code. 🚨"
+                    echo 1
+                  fi
+
+  fail_junit:
+    parameters:
+      <<: *windows-param
+    description: Start a run that will fail
+    steps:
+      - when:
+          condition: << parameters.windows >>
+          steps:
+            - run:
+                name: Start a run that will fail
+                command: |
+                  ./rainforest.exe --skip-update run --run-group 9503 --junit-file junit-fail.xml
+                  if ($LastExitCode -gt 0) {
+                    echo "TESTING ::: Got the expected non-zero exit code."
+                    exit 0
+                  } else {
+                    echo "TESTING ::: Got UNEXPECTED zero exit code."
+                    exit 1
+                  }
+      - unless:
+          condition: << parameters.windows >>
+          steps:
+            - run:
+                name: Start a run that will fail, with junit
+                command: |
+                  set +e
+                  ./rainforest --skip-update run --run-group 9503 --junit-file junit-fail.xml
+                  if [[ $? != 0 ]]; then
+                    echo "TESTING ::: Got the expected non-zero exit code. ✅"
+                    echo 0
+                  else
+                    echo "TESTING ::: Got UNEXPECTED zero exit code. 🚨"
+                    echo 1
+                  fi
+      - store_test_results:
+          path: junit-fail.xml
+
 jobs:
   validate_goreleaser_config:
-    <<: *defaults
+    executor: linux
     steps:
       - checkout
       - run:
@@ -70,7 +165,7 @@ jobs:
           name: Check GoReleaser Config
           command: goreleaser check
   test:
-    <<: *defaults
+    executor: linux
     steps:
       - checkout
       - run:
@@ -82,194 +177,37 @@ jobs:
       - store_test_results:
           path: report.xml
 
-  integration_mac_pass:
-    <<: *mac
+  integration_test:
+    parameters:
+      platform:
+        # type: string rather than executor; otherwise the conditions used below won't work
+        # See https://discuss.circleci.com/t/condition-on-executor-type/39711
+        type: string
+      test:
+        type: steps
+    executor: << parameters.platform >>
     steps:
       - checkout
-      - install_go_darwin
-      - go_build
-      - run:
-          name: Start a run that will pass
-          command: |
-            ./rainforest --skip-update run --run-group 9502
-
-  integration_mac_pass_junit:
-    <<: *mac
-    steps:
-      - checkout
-      - install_go_darwin
-      - go_build
-      - run:
-          name: Start a run that will pass, with junit
-          command: |
-            ./rainforest --skip-update run --run-group 9502 --junit-file junit-pass.xml
-      - store_test_results:
-          path: junit-pass.xml
-
-  integration_mac_fail:
-    <<: *mac
-    steps:
-      - checkout
-      - install_go_darwin
-      - go_build
-      - run:
-          name: Start a run that will fail
-          command: |
-            set +e
-            ./rainforest --skip-update run --run-group 9503
-            if [[ $? != 0 ]]; then
-              echo "TESTING ::: Got the expected non-zero exit code. ✅"
-              echo 0
-            else
-              echo "TESTING ::: Got UNEXPECTED zero exit code. 🚨"
-              echo 1
-            fi
-
-  integration_mac_fail_junit:
-    <<: *mac
-    steps:
-      - checkout
-      - install_go_darwin
-      - go_build
-      - run:
-          name: Start a run that will fail, with junit
-          command: |
-            set +e
-            ./rainforest --skip-update run --run-group 9503 --junit-file junit-fail.xml
-            if [[ $? != 0 ]]; then
-              echo "TESTING ::: Got the expected non-zero exit code. ✅"
-              echo 0
-            else
-              echo "TESTING ::: Got UNEXPECTED zero exit code. 🚨"
-              echo 1
-            fi
-      - store_test_results:
-          path: junit-fail.xml
-
-  integration_linux_pass:
-    <<: *defaults
-    steps:
-      - checkout
-      - go_build
-      - run:
-          name: Start a run that will pass
-          command: |
-            ./rainforest --skip-update run --run-group 9502
-
-  integration_linux_pass_junit:
-    <<: *defaults
-    steps:
-      - checkout
-      - go_build
-      - run:
-          name: Start a run that will pass, with junit
-          command: |
-            ./rainforest --skip-update run --run-group 9502 --junit-file junit-pass.xml
-      - store_test_results:
-          path: junit-pass.xml
-
-  integration_linux_fail:
-    <<: *defaults
-    steps:
-      - checkout
-      - go_build
-      - run:
-          name: Start a run that will fail
-          command: |
-            set +e
-            ./rainforest --skip-update run --run-group 9503
-            if [[ $? != 0 ]]; then
-              echo "TESTING ::: Got the expected non-zero exit code. ✅"
-              echo 0
-            else
-              echo "TESTING ::: Got UNEXPECTED zero exit code. 🚨"
-              echo 1
-            fi
-
-  integration_linux_fail_junit:
-    <<: *defaults
-    steps:
-      - checkout
-      - go_build
-      - run:
-          name: Start a run that will fail, with junit
-          command: |
-            set +e
-            ./rainforest --skip-update run --run-group 9503 --junit-file junit-fail.xml
-            if [[ $? != 0 ]]; then
-              echo "TESTING ::: Got the expected non-zero exit code. ✅"
-              exit 0
-            else
-              echo "TESTING ::: Got UNEXPECTED zero exit code. 🚨"
-              exit 1
-            fi
-      - store_test_results:
-          path: junit-fail.xml
-
-  integration_windows_pass:
-    <<: *windows
-    steps:
-      - checkout
-      - go_build:
-          windows: true
-      - run:
-          name: Run rainforest
-          command: |
-            ./rainforest.exe --skip-update run --run-group 9502
-
-  integration_windows_pass_junit:
-    <<: *windows
-    steps:
-      - checkout
-      - go_build:
-          windows: true
-      - run:
-          name: Run rainforest with junit output
-          command: |
-            ./rainforest.exe --skip-update run --run-group 9502 --junit-file junit-pass.xml
-      - store_test_results:
-          path: junit-pass.xml
-
-  integration_windows_fail:
-    <<: *windows
-    steps:
-      - checkout
-      - go_build:
-          windows: true
-      - run:
-          name: Run rainforest
-          command: |
-            ./rainforest.exe --skip-update run --run-group 9503
-            if ($LastExitCode -gt 0) {
-              echo "TESTING ::: Got the expected non-zero exit code."
-              exit 0
-            } else {
-              echo "TESTING ::: Got UNEXPECTED zero exit code."
-              exit 1
-            }
-
-  integration_windows_fail_junit:
-    <<: *windows
-    steps:
-      - checkout
-      - go_build:
-          windows: true
-      - run:
-          name: Run rainforest with junit output
-          command: |
-            ./rainforest.exe --skip-update run --run-group 9503 --junit-file junit-fail.xml
-            if ($LastExitCode -gt 0) {
-              echo "TESTING ::: Got the expected non-zero exit code."
-              exit 0
-            } else {
-              echo "TESTING ::: Got UNEXPECTED zero exit code."
-              exit 1
-            }
-      - store_test_results:
-          path: junit-fail.xml
+      - when:
+          condition:
+            equal: [ << parameters.platform >>,  mac ]
+          steps:
+            - install_go_darwin
+      - when:
+          condition:
+            equal: [ << parameters.platform >>,  windows ]
+          steps:
+            - go_build:
+                windows: true
+      - unless:
+          condition:
+            equal: [ << parameters.platform >>,  windows ]
+          steps:
+            - go_build
+      - steps: << parameters.test >>
 
   release:
-    <<: *defaults
+    executor: linux
     steps:
       - checkout
       - run:
@@ -289,53 +227,30 @@ workflows:
     jobs:
       - test
       - validate_goreleaser_config
-      - integration_mac_pass:
+      - integration_test:
           requires:
             - test
             - validate_goreleaser_config
-      - integration_mac_pass_junit:
-          requires:
-            - test
-      - integration_mac_fail:
-          requires:
-            - test
-            - validate_goreleaser_config
-      - integration_mac_fail_junit:
-          requires:
-            - test
-            - validate_goreleaser_config
-      - integration_linux_pass:
+          matrix:
+            parameters:
+              platform: [linux, mac]
+              test:
+                - [pass]
+                - [pass_junit]
+                - [fail]
+                - [fail_junit]
+      - integration_test:
           requires:
             - test
             - validate_goreleaser_config
-      - integration_linux_pass_junit:
-          requires:
-            - test
-            - validate_goreleaser_config
-      - integration_linux_fail:
-          requires:
-            - test
-            - validate_goreleaser_config
-      - integration_linux_fail_junit:
-          requires:
-            - test
-            - validate_goreleaser_config
-      - integration_windows_pass:
-          requires:
-            - test
-            - validate_goreleaser_config
-      - integration_windows_pass_junit:
-          requires:
-            - test
-            - validate_goreleaser_config
-      - integration_windows_fail:
-          requires:
-            - test
-            - validate_goreleaser_config
-      - integration_windows_fail_junit:
-          requires:
-            - test
-            - validate_goreleaser_config
+          matrix:
+            parameters:
+              platform: [windows]
+              test:
+                - [pass: { windows: true }]
+                - [pass_junit: { windows: true }]
+                - [fail: { windows: true }]
+                - [fail_junit: { windows: true }]
       - release:
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,6 +81,30 @@ commands:
       - store_test_results:
           path: junit-pass.xml
 
+  pass_save_run_id:
+    parameters:
+      <<: *windows-param
+    description: Start a run that will pass, saving the run ID
+    steps:
+      - when:
+          condition: << parameters.windows >>
+          steps:
+            - run:
+                name: Start a run that will pass, saving the run ID
+                command: |
+                  ./rainforest.exe --skip-update run --run-group 9502 --save-run-id rf_run_id
+                  Get-Content rf_run_id | Select-String -Pattern "^\d+$"
+      - unless:
+          condition: << parameters.windows >>
+          steps:
+            - run:
+                name: Start a run that will pass, saving the run ID
+                command: |
+                  ./rainforest --skip-update run --run-group 9502 --save-run-id rf_run_id
+                  cat rf_run_id | grep -E "^[0-9]+$"
+      - store_artifacts:
+          path: rf_run_id
+
   fail:
     parameters:
       <<: *windows-param
@@ -237,6 +261,7 @@ workflows:
               test:
                 - [pass]
                 - [pass_junit]
+                - [pass_save_run_id]
                 - [fail]
                 - [fail_junit]
       - integration_test:
@@ -249,6 +274,7 @@ workflows:
               test:
                 - [pass: { windows: true }]
                 - [pass_junit: { windows: true }]
+                - [pass_save_run_id: { windows: true }]
                 - [fail: { windows: true }]
                 - [fail_junit: { windows: true }]
       - release:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Rainforest CLI Changelog
+## 2.25.0 - 2021-12-03
+- Add `--save-run-id` flag to `run` and `rerun` commands
+  - (febe8f4a24426a17cc6fd2cdb1485da3e9e9a763, @magni-)
+- Output logging when CLI is autoupdated
+  - (c99798c17582625e0e3c499a523740408b1907a2, @magni-)
 ## 2.24.0 - 2021-11-18
 - Add support for upcoming GitHub Action
   - (e00cc08571ba66b2d0cc5e982de7d28f850bde4a, @magni-)

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/rhysd/go-github-selfupdate v1.2.3
 	github.com/satori/go.uuid v1.2.0
 	github.com/ukd1/go.detectci v0.0.0-20210512015713-5570f6cb6bb1
-	github.com/urfave/cli v0.0.0-20160622145533-4205e9c4ee96
+	github.com/urfave/cli v1.22.5
 	github.com/whilp/git-urls v1.0.0
 	gopkg.in/check.v1 v1.0.0-20200902074654-038fdea0a05b // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,10 @@
+github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/aws/aws-sdk-go v1.34.18 h1:Mo/Clq3u1dQFzpg8YQqBii8m+Vl3fWIfHi6kXs5wpuM=
 github.com/aws/aws-sdk-go v1.34.18/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
+github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d h1:U+s90UTSYgptZMwQh2aRr3LuazLJIa+Pg3Kc1ylSYVY=
+github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
@@ -45,8 +48,12 @@ github.com/rainforestapp/go-github-selfupdate v1.2.4-0.20210729013827-905f4fc542
 github.com/rainforestapp/go-github-selfupdate v1.2.4-0.20210729013827-905f4fc54255/go.mod h1:mp/N8zj6jFfBQy/XMYoWsmfzxazpPAODuqarmPDe2Rg=
 github.com/rainforestapp/testutil v0.0.0-20170615220520-c9155e7da96e h1:yF1mXdyl6i50XquzDkzkGSwLf+fnClYwsOwq0TH2Lxw=
 github.com/rainforestapp/testutil v0.0.0-20170615220520-c9155e7da96e/go.mod h1:wYy1wh1VsTxLVSTvfYS+nOHmZGsvFqOSBJKHVsAYtlM=
+github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0RK8m9o+Q=
+github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/satori/go.uuid v1.2.0 h1:0uYX9dsZ2yD7q2RtLRtPSdGDWzjeM3TbMJP9utgA0ww=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
+github.com/shurcooL/sanitized_anchor_name v1.0.0 h1:PdmoCO6wvbs+7yrJyMORt4/BmY5IYyJwS/kOiWx8mHo=
+github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
@@ -56,8 +63,8 @@ github.com/ukd1/go.detectci v0.0.0-20210512015713-5570f6cb6bb1 h1:xiWH1W14cPO/ZI
 github.com/ukd1/go.detectci v0.0.0-20210512015713-5570f6cb6bb1/go.mod h1:YY61fPGXWrgJ7P06q5IF+jWcyyZoiyPzfkNN3bqg0BM=
 github.com/ulikunitz/xz v0.5.9 h1:RsKRIA2MO8x56wkkcd3LbtcE/uMszhb6DpRf+3uwa3I=
 github.com/ulikunitz/xz v0.5.9/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
-github.com/urfave/cli v0.0.0-20160622145533-4205e9c4ee96 h1:UWALEFwlzMxL33kyyW+7VuTGnWe9uWvQ1zGWcCSFD7c=
-github.com/urfave/cli v0.0.0-20160622145533-4205e9c4ee96/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
+github.com/urfave/cli v1.22.5 h1:lNq9sAHXK2qfdI8W+GRItjCEkI+2oR4d+MEHy1CKXoU=
+github.com/urfave/cli v1.22.5/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/whilp/git-urls v1.0.0 h1:95f6UMWN5FKW71ECsXRUd3FVYiXdrE7aX4NZKcPmIjU=
 github.com/whilp/git-urls v1.0.0/go.mod h1:J16SAmobsqc3Qcy98brfl5f5+e0clUvg1krgwk/qCfE=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/rainforest-cli.go
+++ b/rainforest-cli.go
@@ -162,11 +162,11 @@ func main() {
 			Flags: []cli.Flag{
 				cli.BoolFlag{
 					Name:  "f, files",
-					Usage: "run local tests specified by `FILES or FOLDERS`",
+					Usage: "Run local tests specified by `FILES or FOLDERS`",
 				},
 				cli.StringSliceFlag{
 					Name:  "tag",
-					Usage: "filter tests by `TAG`. Can be used multiple times for filtering by multiple tags.",
+					Usage: "Filter tests by `TAG`. Can be used multiple times for filtering by multiple tags.",
 				},
 				cli.StringSliceFlag{
 					Name:  "exclude",
@@ -178,66 +178,66 @@ func main() {
 				},
 				cli.StringFlag{
 					Name:  "site, site-id",
-					Usage: "filter tests by a specific site. You can see a list of your `SITE-ID`s with the sites command.",
+					Usage: "Filter tests by a specific site. You can see a list of your `SITE-ID`s with the sites command.",
 				},
 				cli.StringFlag{
 					Name:  "folder, folder-id, filter, filter-id",
-					Usage: "filter tests by a specific folder. You can see a list of your `FOLDER-ID`s with the folders command.",
+					Usage: "Filter tests by a specific folder. You can see a list of your `FOLDER-ID`s with the folders command.",
 				},
 				cli.IntFlag{
 					Name:  "feature, feature-id",
-					Usage: "filter tests by a specific feature. You can see a list of your `FEATURE-ID`s with the features command.",
+					Usage: "Filter tests by a specific feature. You can see a list of your `FEATURE-ID`s with the features command.",
 				},
 				cli.IntFlag{
 					Name:  "run-group, run-group-id",
-					Usage: "start a run using a run group. You can see a list of your `RUN-GROUP-ID`s with the run-groups command. This option cannot be used in conjunction with other filtering options.",
+					Usage: "Start a run using a run group. You can see a list of your `RUN-GROUP-ID`s with the run-groups command. This option cannot be used in conjunction with other filtering options.",
 				},
 				cli.StringSliceFlag{
 					Name: "browser, browsers",
-					Usage: "specify the `BROWSER` you wish to run against. This overrides test level settings." +
+					Usage: "Specify the `BROWSER` you wish to run against. This overrides test level settings." +
 						"Can be used multiple times to run against multiple browsers.",
 				},
 				cli.StringFlag{
 					Name:  "environment-id",
-					Usage: "run your tests using specified `ENVIRONMENT`. Otherwise it will use your default one.",
+					Usage: "Run your tests using specified `ENVIRONMENT`. Otherwise it will use your default one.",
 				},
 				cli.StringFlag{
 					Name: "crowd",
-					Usage: "run your tests using specified `CROWD`. Available choices are: default, automation, automation_and_crowd " +
+					Usage: "Run your tests using specified `CROWD`. Available choices are: default, automation, automation_and_crowd " +
 						"or on_premise_crowd. Contact your CSM for more details.",
 				},
 				cli.StringFlag{
 					Name: "conflict",
-					Usage: "use the abort option to abort any runs in the same environment or " +
+					Usage: "Use the abort option to abort any runs in the same environment or " +
 						"use the abort-all option to abort all runs in progress.",
 				},
 				cli.BoolFlag{
 					Name: "bg, background",
-					Usage: "run in the background. This option makes cli return after successfully starting a run, " +
+					Usage: "Run in the background. This option makes cli return after successfully starting a run, " +
 						"without waiting for the run results.",
 				},
 				cli.BoolFlag{
 					Name: "fail-fast, ff",
-					Usage: "fail the build as soon as the first failed result comes in. " +
+					Usage: "Fail the build as soon as the first failed result comes in. " +
 						"If you don't pass this it will wait until 100% of the run is done. Use with --fg.",
 				},
 				cli.StringFlag{
 					Name: "custom-url",
-					Usage: "specify the URL for the run to use when testing against an ephemeral environment. " +
+					Usage: "Specify the URL for the run to use when testing against an ephemeral environment. " +
 						"This will create a new temporary environment for the run.",
 				},
 				cli.BoolFlag{
 					Name: "git-trigger",
-					Usage: "only trigger a run when the last commit (for a git repo in the current working directory) " +
+					Usage: "Only trigger a run when the last commit (for a git repo in the current working directory) " +
 						"contains @rainforest and a list of one or more tags. rainforest-cli exits with 0 otherwise.",
 				},
 				cli.StringFlag{
 					Name:  "description",
-					Usage: "add arbitrary `DESCRIPTION` to the run.",
+					Usage: "Add arbitrary `DESCRIPTION` to the run.",
 				},
 				cli.StringFlag{
 					Name: "release",
-					Usage: "adds a `RELEASE` ID that is associated with this run. You can use any string, but commonly used " +
+					Usage: "Adds a `RELEASE` ID that is associated with this run. You can use any string, but commonly used " +
 						"IDs are commit SHAs, build IDs, branch names, etc.",
 				},
 				cli.StringFlag{
@@ -262,7 +262,7 @@ func main() {
 				},
 				cli.StringFlag{
 					Name:  "wait, reattach",
-					Usage: "monitor existing run with `RUN_ID` instead of starting a new one.",
+					Usage: "Monitor existing run with `RUN_ID` instead of starting a new one.",
 				},
 				cli.UintFlag{
 					Name:  "max-reruns",
@@ -288,17 +288,17 @@ func main() {
 			Flags: []cli.Flag{
 				cli.StringFlag{
 					Name: "conflict",
-					Usage: "use the abort option to abort any runs in the same environment or " +
+					Usage: "Use the abort option to abort any runs in the same environment or " +
 						"use the abort-all option to abort all runs in progress.",
 				},
 				cli.BoolFlag{
 					Name: "bg, background",
-					Usage: "run in the background. This option makes cli return after successfully starting a run, " +
+					Usage: "Run in the background. This option makes cli return after successfully starting a run, " +
 						"without waiting for the run results.",
 				},
 				cli.BoolFlag{
 					Name: "fail-fast, ff",
-					Usage: "fail the build as soon as the first failed result comes in. " +
+					Usage: "Fail the build as soon as the first failed result comes in. " +
 						"If you don't pass this it will wait until 100% of the run is done. Use with --fg.",
 				},
 				cli.StringFlag{
@@ -375,7 +375,7 @@ func main() {
 				},
 				cli.BoolFlag{
 					Name:  "synchronous-upload",
-					Usage: "uploads your test in a synchronous manner i.e. not using concurrency.",
+					Usage: "Uploads your test in a synchronous manner i.e. not using concurrency.",
 				},
 			},
 			Action: func(c *cli.Context) error {
@@ -405,23 +405,23 @@ func main() {
 			Flags: []cli.Flag{
 				cli.StringSliceFlag{
 					Name:  "tag",
-					Usage: "filter tests by `TAG`. Can be used multiple times for filtering by multiple tags.",
+					Usage: "Filter tests by `TAG`. Can be used multiple times for filtering by multiple tags.",
 				},
 				cli.IntFlag{
 					Name:  "site, site-id",
-					Usage: "filter tests by a specific site. You can see a list of your `SITE-ID`s with the sites command.",
+					Usage: "Filter tests by a specific site. You can see a list of your `SITE-ID`s with the sites command.",
 				},
 				cli.IntFlag{
 					Name:  "folder, folder-id, filter, filter-id",
-					Usage: "filter tests by a specific folder. You can see a list of your `FOLDER-ID`s with the folders command.",
+					Usage: "Filter tests by a specific folder. You can see a list of your `FOLDER-ID`s with the folders command.",
 				},
 				cli.IntFlag{
 					Name:  "feature, feature-id",
-					Usage: "filter tests by a specific feature. You can see a list of your `FEATURE-ID`s with the features command.",
+					Usage: "Filter tests by a specific feature. You can see a list of your `FEATURE-ID`s with the features command.",
 				},
 				cli.IntFlag{
 					Name:  "run-group, run-group-id",
-					Usage: "filter tests by a specific run group. You can see a list of your `RUN-GROUP-ID`s with the run-groups command.",
+					Usage: "Filter tests by a specific run group. You can see a list of your `RUN-GROUP-ID`s with the run-groups command.",
 				},
 				cli.StringFlag{
 					Name:   "test-folder",
@@ -431,7 +431,7 @@ func main() {
 				},
 				cli.BoolFlag{
 					Name:  "flatten-steps",
-					Usage: "download your tests with steps extracted from embedded tests.",
+					Usage: "Download your tests with steps extracted from embedded tests.",
 				},
 			},
 			Action: func(c *cli.Context) error {

--- a/rainforest-cli.go
+++ b/rainforest-cli.go
@@ -152,7 +152,9 @@ func main() {
 			Aliases:      []string{"r"},
 			Usage:        "Run your tests on Rainforest",
 			OnUsageError: onCommandUsageErrorHandler("run"),
-			Action:       startRun,
+			Action:       func(c *cli.Context) error {
+				return startRun(c)
+			},
 			Description: "Runs your tests on Rainforest platform. " +
 				"You need to specify list of test IDs to run or use keyword 'all'. " +
 				"Alternatively you can use one of the filtering options.",
@@ -273,7 +275,9 @@ func main() {
 			Aliases:      []string{"rr"},
 			Usage:        "Rerun failed tests from a previous run",
 			OnUsageError: onCommandUsageErrorHandler("rerun"),
-			Action:       rerunRun,
+			Action:       func(c *cli.Context) error {
+				return rerunRun(c)
+			},
 			Description: "Reruns the failed tests from a previous run on Rainforest platform. " +
 				"Parameters such as 'environment', 'crowd', 'release', etc. are copied from the previous run.",
 			ArgsUsage: "[run ID]",
@@ -322,7 +326,9 @@ func main() {
 					EnvVar: "RAINFOREST_TEST_FOLDER",
 				},
 			},
-			Action: newRFMLTest,
+			Action: func(c *cli.Context) error {
+				return newRFMLTest(c)
+			},
 		},
 		{
 			Name:         "validate",
@@ -373,7 +379,9 @@ func main() {
 			OnUsageError: onCommandUsageErrorHandler("rm"),
 			ArgsUsage:    "[path to RFML file]",
 			Description:  "Remove RFML file and remove test from Rainforest test suite.",
-			Action:       deleteRFML,
+			Action:       func(c *cli.Context) error {
+				return deleteRFML(c)
+			},
 		},
 		{
 			Name: "download",
@@ -552,7 +560,9 @@ func main() {
 			Name:         "update",
 			Usage:        "Updates application to the latest version",
 			OnUsageError: onCommandUsageErrorHandler("update"),
-			Action:       updateCmd,
+			Action:       func(c *cli.Context) error {
+				return updateCmd(c)
+			},
 		},
 	}
 

--- a/rainforest-cli.go
+++ b/rainforest-cli.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	// Version of the app in SemVer
-	version = "2.24.0"
+	version = "2.25.0"
 	// This is the default spec folder for RFML tests
 	defaultSpecFolder = "./spec/rainforest"
 )

--- a/rainforest-cli.go
+++ b/rainforest-cli.go
@@ -268,6 +268,10 @@ func main() {
 					Name:  "max-reruns",
 					Usage: "Rerun `max-reruns` times before reporting failure.",
 				},
+				cli.StringFlag{
+					Name:  "save-run-id",
+					Usage: "Save the created run's ID to `FILE`",
+				},
 			},
 		},
 		{
@@ -308,6 +312,11 @@ func main() {
 				cli.UintFlag{
 					Name:  "rerun-attempt",
 					Usage: "Which rerun attempt this is.",
+				},
+				cli.StringFlag{
+					Name:  "save-run-id",
+					Usage: "Save the created run's ID to `FILE`",
+					Value: ".rainforest_run_id",
 				},
 			},
 		},

--- a/runner.go
+++ b/runner.go
@@ -108,6 +108,7 @@ func (r *runner) startRun(c cliContext) error {
 		return cli.NewExitError(err.Error(), 1)
 	}
 	r.showRunCreated(runStatus)
+	writeRunID(c, runStatus)
 
 	// if background flag is enabled we'll skip monitoring run status
 	if c.Bool("bg") {
@@ -128,6 +129,7 @@ func (r *runner) rerunRun(c cliContext) error {
 		return cli.NewExitError(err.Error(), 1)
 	}
 	r.showRunCreated(runStatus)
+	writeRunID(c, runStatus)
 
 	// if background flag is enabled we'll skip monitoring run status
 	if c.Bool("bg") {
@@ -537,4 +539,23 @@ func expandStringSlice(slice []string) []string {
 		}
 	}
 	return result
+}
+
+// writeRunID writes the run ID to a file if the flag is set
+func writeRunID(c cliContext, runStatus *rainforest.RunStatus) error {
+	filePath := c.String("save-run-id")
+	if filePath == "" {
+		return nil
+	}
+
+	file, err := os.Create(filePath)
+	defer file.Close()
+
+	if err != nil {
+		return cli.NewExitError(err.Error(), 1)
+	} else {
+		file.WriteString(fmt.Sprintf("%v\n", runStatus.ID))
+	}
+
+	return nil
 }

--- a/update.go
+++ b/update.go
@@ -22,12 +22,10 @@ func update(silent bool) error {
 	if err != nil {
 		return err
 	}
-	if !silent {
-		if latest.Version.Equals(v) {
-			log.Println("No update available, already at the latest version!")
-		} else {
-			log.Printf("Updated to new version: %s!\n", latest.Version)
-		}
+	if !silent && latest.Version.Equals(v) {
+		log.Println("No update available, already at the latest version!")
+	} else if latest.Version.NE(v) {
+		log.Printf("Updated to new version: %s!\n", latest.Version)
 	}
 
 	return nil


### PR DESCRIPTION
This is so that the CircleCI Orb and GitHub Actions can easily fetch the run ID for rerun purposes, without needing to install `libxml` to parse the JUnit each time (the workaround they're currently using).

I didn't add it to the README because I figured it's not of much use for other use cases? The flag is documented in the CLI itself.

I also updated `urfave/cli` to v1 latest since we were still on a super old SHA (not even a tag), which was annoying when reading their documentation. Upgrading to v2 involves breaking changes (most notably, it'll require users to set all flags before passing in arguments), so I opted against doing that in this PR.