### PR TITLE
RF-23162 Switch to latest Xcode version in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ windows-param: &windows-param
 executors:
   mac:
     macos:
-      xcode: 11.3.0
+      xcode: 13.2.0
   linux:
     docker:
       - image: cimg/go:1.17.1-node


### PR DESCRIPTION
The version we're currently using are deprecated and will be removed next month: https://discuss.circleci.com/t/deprecation-notice-xcode-11-0-0-11-1-0-11-2-1-11-3-1/42261
