### PR TITLE
RF-23329 - Update allowed extensions for mobile app uploads to include `.aab`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,18 @@
 # Rainforest CLI Changelog
+## 2.27.0 - 2022-01-20
+- Update allowed extensions for mobile app uploads to include `.aab`
+  - (45ed97d1e6b05637d8325f7dcbf98de4f2e7ab61, @ubergeek42)
+
 ## 2.26.0 - 2022-01-12
 - Add `--automation-max-retries` flag to the `run` command.
   - (70061750b7675c7e4ee1c422ac2c914a3ef7cc8e, @maciejgryka)
+
 ## 2.25.0 - 2021-12-03
 - Add `--save-run-id` flag to `run` and `rerun` commands
   - (febe8f4a24426a17cc6fd2cdb1485da3e9e9a763, @magni-)
 - Output logging when CLI is autoupdated
   - (c99798c17582625e0e3c499a523740408b1907a2, @magni-)
+
 ## 2.24.0 - 2021-11-18
 - Add support for upcoming GitHub Action
   - (e00cc08571ba66b2d0cc5e982de7d28f850bde4a, @magni-)

--- a/mobile_upload.go
+++ b/mobile_upload.go
@@ -42,13 +42,13 @@ func uploadMobileApp(api mobileUploadAPI, filePath string, siteID int, environme
 
 func isAllowedExtension(extension string) bool {
 	switch extension {
-	case ".apk", ".ipa", ".zip", ".gz", ".tar.gz":
+	case ".apk", ".aab", ".ipa", ".zip", ".gz", ".tar.gz":
 		return true
 	}
 	return false
 }
 
-const allowedExtensionsPretty = ".apk, .ipa, .zip, .gz, .tar.gz"
+const allowedExtensionsPretty = ".apk, .aab, .ipa, .zip, .gz, .tar.gz"
 
 // mobileAppUpload is a wrapper around uploadMobileApp to function with mobile-upload cli command
 func mobileAppUpload(c cliContext, api mobileUploadAPI) error {

--- a/rainforest-cli.go
+++ b/rainforest-cli.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	// Version of the app in SemVer
-	version = "2.26.0"
+	version = "2.27.0"
 	// This is the default spec folder for RFML tests
 	defaultSpecFolder = "./spec/rainforest"
 )


### PR DESCRIPTION
Rainforest now supports Android App Bundles, so we should let the cli upload them.