### PR TITLE
[RF-22235] Update terminology

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,14 @@
 # Rainforest CLI Changelog
+## 2.29.0 - 2022-03-16
+- Add `cancel` and `cancel-all` options for `--conflict` flag to replace deprecated `abort` and `abort-all`
+  - (88882b0b27a5665c552d6c60459f11076be59a41, @magni-)
+- Replace `browsers` command with `platforms`
+  - (419484b877cb79591e601b8f739e6f6e148bf20b, @magni-)
+- Add new `--platform` (also aliased as `--platforms`) flag to replace deprecated `--browser` and `--browsers` flags
+  - (33b9d9e54b547d19f659e6c5e6402d88c812fe0f, @magni-)
+- Replace `# browsers:` RFML magic comment with `# platforms:`
+  - (81f79648a22e7d95b21738789ec6f672ec2152c9, @magni-)
+
 ## 2.28.0 - 2022-02-24
 - Provide better error message when trying to download unsupported tests.
   - (5908c8ee15187ed69c37aa5d92a678e211ee14ac, @pyromaniackeca)

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ The following options are specific to `run -f` or behave differently:
 - `--exclude FILE`: exclude the test in `FILE` from being run, even if `# execute: true` is specified.
 - `--force-execute FILE`: execute the test in `FILE` even if `# execute: false` is specified.
 
-Run-level setting options (`--browsers`, `--environment_id`, etc) behave the same for `run -f`. Other test filtering options (such as `--run-group`, `--site`, etc) cannot be used in conjunction with `run -f`.
+Run-level setting options (`--platforms`, `--environment_id`, etc) behave the same for `run -f`. Other test filtering options (such as `--run-group`, `--site`, etc) cannot be used in conjunction with `run -f`.
 
 #### Viewing Account Specific Information
 
@@ -335,7 +335,7 @@ For more information on embedding inline screenshots and file downloads,
 ### Command Line Options
 
 Popular command line options are:
-- `--browsers ie8` or `--browsers ie8,chrome` - specify the platforms you wish to run against. This overrides the test level settings. Valid platforms can be found in your account settings.
+- `--platform ie8` or `--platforms ie8,chrome` - specify the platform(s) you wish to run against. This overrides the test level settings. Valid platforms can be found in your account settings.
 - `--tag TAG_NAME` - filter tests by tag. Can be used multiple times for filtering by multiple tags.
 - `--site-id SITE_ID` - filter tests by a specific site. You can see a list of your site IDs with `rainforest sites`.
 - `--folder ID/--filter ID` - filter tests in specified folder.

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ rainforest run all --bg
 Run all tests with tag 'run-me' and cancel previous in-progress runs.
 
 ```bash
-rainforest run --tag run-me --conflict abort
+rainforest run --tag run-me --conflict cancel
 ```
 
 Run all tests and generate a junit xml report.
@@ -342,7 +342,7 @@ Popular command line options are:
 - `--feature ID` - filter tests in a feature.
 - `--run-group ID` - run/filter based on a run group. When used with `run`, this trigger a run from the run group; it can't be used in conjunction with other test filters.
 - `--environment-id` - run your tests using this environment. Otherwise it will use your default environment
-- `--conflict OPTION` - use the `abort` option to cancel any runs in progress in the same environment as your new run. Use the `abort-all` option to cancel all runs in progress.
+- `--conflict OPTION` - use the `cancel` option to cancel any runs in progress in the same environment as your new run. Use the `cancel-all` option to cancel all runs in progress.
 - `--bg` - creates a run in the background and rainforest-cli exits immediately after. Do not use if you want rainforest-cli to track your run and exit with an error code upon run failure (ie: using Rainforest in your CI environment). Cannot be used together with `--max-reruns`.
 - `--crowd [default|automation|automation_and_crowd|on_premise_crowd]` - select automation or your crowd of testers (for clients with on premise testers). For more information, contact us at help@rainforestqa.com.
 - `--wait RUN_ID` - wait for an existing run to finish instead of starting a new one, and exit with a non-0 code if the run fails. rainforest-cli will exit immediately if the run is already complete.

--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ Rainforest Tests written using RFML have the following format
 # start_uri: [START_URI]
 # tags: [TAGS]
 # site_id: [SITE ID]
-# browsers: [PLATFORM IDS]
+# platforms: [PLATFORM IDS]
 # feature_id: [FEATURE_ID]
 # state: [STATE]
 # [OTHER COMMENTS]

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Run all your tests in the background and exit the process immediately.
 rainforest run all --bg
 ```
 
-Run all tests with tag 'run-me' and abort previous in-progress runs.
+Run all tests with tag 'run-me' and cancel previous in-progress runs.
 
 ```bash
 rainforest run --tag run-me --conflict abort
@@ -101,7 +101,7 @@ rainforest run <test_id1> <test_id2>
 
 Run a run group.
 
-⚠️ This uses the configuration defined in the run group (environment, browsers, crowd, location). If you wish to run tests from a run group without using the run group's configuration, you will need to use the Rainforest API directly, passing a `run_group_id` parameter to [the `POST /runs` endpoint](https://app.rainforestqa.com/docs#!/runs/post1Runs). ⚠️
+⚠️ This uses the configuration defined in the run group (environment, platforms, crowd, location). If you wish to run tests from a run group without using the run group's configuration, you will need to use the Rainforest API directly, passing a `run_group_id` parameter to [the `POST /runs` endpoint](https://app.rainforestqa.com/docs#!/runs/post1Runs). ⚠️
 
 ```bash
 rainforest run --run-group <run_group_id>
@@ -219,7 +219,7 @@ See a list of all of your smart folders and their IDs
 rainforest folders
 ```
 
-See a list of all of your browsers and their IDs
+See a list of all of your platforms and their IDs
 ```bash
 rainforest browsers
 ```
@@ -278,7 +278,7 @@ Rainforest Tests written using RFML have the following format
 # start_uri: [START_URI]
 # tags: [TAGS]
 # site_id: [SITE ID]
-# browsers: [BROWSER IDS]
+# browsers: [PLATFORM IDS]
 # feature_id: [FEATURE_ID]
 # state: [STATE]
 # [OTHER COMMENTS]
@@ -313,9 +313,9 @@ Optional Fields:
 - `SITE ID` - Site ID for the site this test is for. You can find your available
 site IDs with the `sites` command. Sites can be configured at
 https://app.rainforestqa.com/settings/sites.
-- `BROWSER IDS` - Comma separated list of browsers for this test. You can reference
-your available browsers with the `browsers` command. If left empty or omitted,
-your test will default to using your account's default browsers.
+- `PLATFORM IDS` - Comma separated list of platforms for this test. You can reference
+your available platforms with the `browsers` command. If left empty or omitted,
+your test will default to using your account's default platforms.
 - `TAGS` - Comma separated list of your desired tags for this test.
 - `FEATURE_ID` - Feature ID for the feature that this test is a part of. You can
 find your available feature IDs with the `features` command.
@@ -335,14 +335,14 @@ For more information on embedding inline screenshots and file downloads,
 ### Command Line Options
 
 Popular command line options are:
-- `--browsers ie8` or `--browsers ie8,chrome` - specify the browsers you wish to run against. This overrides the test level settings. Valid browsers can be found in your account settings.
+- `--browsers ie8` or `--browsers ie8,chrome` - specify the platforms you wish to run against. This overrides the test level settings. Valid platforms can be found in your account settings.
 - `--tag TAG_NAME` - filter tests by tag. Can be used multiple times for filtering by multiple tags.
 - `--site-id SITE_ID` - filter tests by a specific site. You can see a list of your site IDs with `rainforest sites`.
 - `--folder ID/--filter ID` - filter tests in specified folder.
 - `--feature ID` - filter tests in a feature.
 - `--run-group ID` - run/filter based on a run group. When used with `run`, this trigger a run from the run group; it can't be used in conjunction with other test filters.
 - `--environment-id` - run your tests using this environment. Otherwise it will use your default environment
-- `--conflict OPTION` - use the `abort` option to abort any runs in progress in the same environment as your new run. use the `abort-all` option to abort all runs in progress.
+- `--conflict OPTION` - use the `abort` option to cancel any runs in progress in the same environment as your new run. Use the `abort-all` option to cancel all runs in progress.
 - `--bg` - creates a run in the background and rainforest-cli exits immediately after. Do not use if you want rainforest-cli to track your run and exit with an error code upon run failure (ie: using Rainforest in your CI environment). Cannot be used together with `--max-reruns`.
 - `--crowd [default|automation|automation_and_crowd|on_premise_crowd]` - select automation or your crowd of testers (for clients with on premise testers). For more information, contact us at help@rainforestqa.com.
 - `--wait RUN_ID` - wait for an existing run to finish instead of starting a new one, and exit with a non-0 code if the run fails. rainforest-cli will exit immediately if the run is already complete.

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ rainforest run <test_id1> <test_id2>
 
 Run a run group.
 
-⚠️ This uses the configuration defined in the run group (environment, platforms, crowd, location). If you wish to run tests from a run group without using the run group's configuration, you will need to use the Rainforest API directly, passing a `run_group_id` parameter to [the `POST /runs` endpoint](https://app.rainforestqa.com/docs#!/runs/post1Runs). ⚠️
+⚠️ This uses the configuration defined in the run group (environment, platforms, crowd, location). If you wish to run tests from a run group without using the run group's configuration, you will need to use the Rainforest API directly, passing a `run_group_id` parameter to [the `POST /runs` endpoint](https://help.rainforestqa.com/reference/post-runs). ⚠️
 
 ```bash
 rainforest run --run-group <run_group_id>

--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ rainforest folders
 
 See a list of all of your platforms and their IDs
 ```bash
-rainforest browsers
+rainforest platforms
 ```
 
 See a list of all of your features and their IDs
@@ -313,8 +313,8 @@ Optional Fields:
 - `SITE ID` - Site ID for the site this test is for. You can find your available
 site IDs with the `sites` command. Sites can be configured at
 https://app.rainforestqa.com/settings/sites.
-- `PLATFORM IDS` - Comma separated list of platforms for this test. You can reference
-your available platforms with the `browsers` command. If left empty or omitted,
+- `PLATFORMS IDS` - Comma separated list of platforms for this test. You can reference
+your available platforms with the `platforms` command. If left empty or omitted,
 your test will default to using your account's default platforms.
 - `TAGS` - Comma separated list of your desired tags for this test.
 - `FEATURE_ID` - Feature ID for the feature that this test is a part of. You can

--- a/rainforest-cli.go
+++ b/rainforest-cli.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	// Version of the app in SemVer
-	version = "2.28.0"
+	version = "2.29.0"
 	// This is the default spec folder for RFML tests
 	defaultSpecFolder = "./spec/rainforest"
 )

--- a/rainforest-cli.go
+++ b/rainforest-cli.go
@@ -194,7 +194,7 @@ func main() {
 				},
 				cli.StringSliceFlag{
 					Name: "platform, platforms",
-					Usage: "Specify the `PLATFORM` you wish to run against. This overrides test level settings." +
+					Usage: "Specify the `PLATFORM` you wish to run against. This overrides test level settings. " +
 						"Can be used multiple times to run against multiple platforms.",
 				},
 				cli.StringSliceFlag{
@@ -262,7 +262,7 @@ func main() {
 				},
 				cli.BoolFlag{
 					Name:  "single-use",
-					Usage: "This option marks uploaded variable as single-use",
+					Usage: "This option marks uploaded variable as single-use.",
 				},
 				cli.StringFlag{
 					Name:  "wait, reattach",
@@ -270,15 +270,15 @@ func main() {
 				},
 				cli.UintFlag{
 					Name:  "max-reruns",
-					Usage: "Rerun `max-reruns` times before reporting failure.",
+					Usage: "Rerun `MAX-RERUNS` times before reporting failure.",
 				},
 				cli.UintFlag{
 					Name:  "automation-max-retries",
-					Usage: "Try to pass a test `automation-max-retries` times within the same run before reporting run failure.",
+					Usage: "Try to pass a test `AUTOMATION-MAX-RETRIES` times within the same run before reporting run failure.",
 				},
 				cli.StringFlag{
 					Name:  "save-run-id",
-					Usage: "Save the created run's ID to `FILE`",
+					Usage: "Save the created run's ID to `FILE`.",
 				},
 			},
 		},
@@ -315,7 +315,7 @@ func main() {
 				},
 				cli.UintFlag{
 					Name:  "max-reruns",
-					Usage: "Rerun `max-reruns` times before reporting failure.",
+					Usage: "Rerun `MAX-RERUNS` times before reporting failure.",
 				},
 				cli.UintFlag{
 					Name:  "rerun-attempt",
@@ -323,7 +323,7 @@ func main() {
 				},
 				cli.StringFlag{
 					Name:  "save-run-id",
-					Usage: "Save the created run's ID to `FILE`",
+					Usage: "Save the created run's ID to `FILE`.",
 					Value: ".rainforest_run_id",
 				},
 			},

--- a/rainforest-cli.go
+++ b/rainforest-cli.go
@@ -546,11 +546,20 @@ func main() {
 			},
 		},
 		{
-			Name:         "browsers",
+			Name:         "platforms",
 			Usage:        "Lists available platforms",
-			OnUsageError: onCommandUsageErrorHandler("browsers"),
+			OnUsageError: onCommandUsageErrorHandler("platforms"),
 			Action: func(c *cli.Context) error {
-				return printBrowsers(api)
+				return printPlatforms(api)
+			},
+		},
+		{
+			Name:         "browsers",
+			Hidden:       true,
+			OnUsageError: onCommandUsageErrorHandler("platforms"),
+			Action: func(c *cli.Context) error {
+				fmt.Println("RF CLI Deprecation: browsers is deprecated; use platforms instead")
+				return printPlatforms(api)
 			},
 		},
 		{

--- a/rainforest-cli.go
+++ b/rainforest-cli.go
@@ -193,9 +193,13 @@ func main() {
 					Usage: "Start a run using a run group. You can see a list of your `RUN-GROUP-ID`s with the run-groups command. This option cannot be used in conjunction with other filtering options.",
 				},
 				cli.StringSliceFlag{
-					Name: "browser, browsers",
+					Name: "platform, platforms",
 					Usage: "Specify the `PLATFORM` you wish to run against. This overrides test level settings." +
 						"Can be used multiple times to run against multiple platforms.",
+				},
+				cli.StringSliceFlag{
+					Name:   "browser, browsers",
+					Hidden: true,
 				},
 				cli.StringFlag{
 					Name:  "environment-id",

--- a/rainforest-cli.go
+++ b/rainforest-cli.go
@@ -194,8 +194,8 @@ func main() {
 				},
 				cli.StringSliceFlag{
 					Name: "browser, browsers",
-					Usage: "Specify the `BROWSER` you wish to run against. This overrides test level settings." +
-						"Can be used multiple times to run against multiple browsers.",
+					Usage: "Specify the `PLATFORM` you wish to run against. This overrides test level settings." +
+						"Can be used multiple times to run against multiple platforms.",
 				},
 				cli.StringFlag{
 					Name:  "environment-id",
@@ -208,8 +208,8 @@ func main() {
 				},
 				cli.StringFlag{
 					Name: "conflict",
-					Usage: "Use the abort option to abort any runs in the same environment or " +
-						"use the abort-all option to abort all runs in progress.",
+					Usage: "Use the abort option to cancel any runs in the same environment or " +
+						"use the abort-all option to cancel all runs in progress.",
 				},
 				cli.BoolFlag{
 					Name: "bg, background",
@@ -292,8 +292,8 @@ func main() {
 			Flags: []cli.Flag{
 				cli.StringFlag{
 					Name: "conflict",
-					Usage: "Use the abort option to abort any runs in the same environment or " +
-						"use the abort-all option to abort all runs in progress.",
+					Usage: "Use the abort option to cancel any runs in the same environment or " +
+						"use the abort-all option to cancel all runs in progress.",
 				},
 				cli.BoolFlag{
 					Name: "bg, background",
@@ -547,7 +547,7 @@ func main() {
 		},
 		{
 			Name:         "browsers",
-			Usage:        "Lists available browsers",
+			Usage:        "Lists available platforms",
 			OnUsageError: onCommandUsageErrorHandler("browsers"),
 			Action: func(c *cli.Context) error {
 				return printBrowsers(api)

--- a/rainforest-cli.go
+++ b/rainforest-cli.go
@@ -208,8 +208,8 @@ func main() {
 				},
 				cli.StringFlag{
 					Name: "conflict",
-					Usage: "Use the abort option to cancel any runs in the same environment or " +
-						"use the abort-all option to cancel all runs in progress.",
+					Usage: "Use the cancel option to cancel any runs in the same environment or " +
+						"use the cancel-all option to cancel all runs in progress.",
 				},
 				cli.BoolFlag{
 					Name: "bg, background",
@@ -292,8 +292,8 @@ func main() {
 			Flags: []cli.Flag{
 				cli.StringFlag{
 					Name: "conflict",
-					Usage: "Use the abort option to cancel any runs in the same environment or " +
-						"use the abort-all option to cancel all runs in progress.",
+					Usage: "Use the cancel option to cancel any runs in the same environment or " +
+						"use the cancel-all option to cancel all runs in progress.",
 				},
 				cli.BoolFlag{
 					Name: "bg, background",

--- a/rainforest/rainforest.go
+++ b/rainforest/rainforest.go
@@ -155,6 +155,13 @@ func (c *Client) NewRequest(method, urlStr string, body interface{}) (*http.Requ
 // checkResponse checks if we received vaild response with code 200,
 // returns error otherwise
 func checkResponse(res *http.Response, debugFlag bool) error {
+	// Log any deprecation warnings returned by the backend
+	if deprecations := res.Header.Get("X-RF-Deprecation"); deprecations != "" {
+		for _, deprecation := range strings.Split(deprecations, "\n") {
+			fmt.Println("RF API Deprecation:", deprecation)
+		}
+	}
+
 	// If we are on a happy path just return nil
 	if res.StatusCode >= 200 && res.StatusCode < 300 {
 		return nil

--- a/rainforest/rainforest_test.go
+++ b/rainforest/rainforest_test.go
@@ -115,6 +115,7 @@ func (res *unreadableResponseBody) Close() error {
 
 func TestCheckResponse(t *testing.T) {
 	contentTypeHeader := textproto.CanonicalMIMEHeaderKey("Content-Type")
+	deprecationHeader := textproto.CanonicalMIMEHeaderKey("X-RF-Deprecation")
 
 	var testCases = []struct {
 		httpResp      *http.Response
@@ -166,6 +167,20 @@ func TestCheckResponse(t *testing.T) {
 			},
 			expectedError: "RF API Error (400) - Unable to parse response JSON: invalid character '(' looking for beginning of value",
 			expectedDebug: "Cannot parse response:\n(this is not json)",
+		},
+		{
+			httpResp: &http.Response{
+				StatusCode: 200,
+				Header:     http.Header{deprecationHeader: {"Stop using that"}},
+			},
+			expectedDebug: "RF API Deprecation: Stop using that",
+		},
+		{
+			httpResp: &http.Response{
+				StatusCode: 200,
+				Header:     http.Header{deprecationHeader: {"Stop using this\nAnd stop using that"}},
+			},
+			expectedDebug: "RF API Deprecation: Stop using this\nRF API Deprecation: And stop using that",
 		},
 	}
 

--- a/rainforest/resources.go
+++ b/rainforest/resources.go
@@ -77,32 +77,32 @@ func (c *Client) GetFolders() ([]Folder, error) {
 	return folders, err
 }
 
-// Browser type represents a single browser returned by the API call for a list of browsers
-type Browser struct {
+// Platform type represents a single platform returned by the API call for a list of platforms
+type Platform struct {
 	Name        string `json:"name"`
 	Description string `json:"description"`
 }
 
-// GetBrowsers returns a slice of Browsers which are available for the client to run
+// GetPlatforms returns a slice of Platforms which are available for the client to run
 // RF tests against.
-func (c *Client) GetBrowsers() ([]Browser, error) {
+func (c *Client) GetPlatforms() ([]Platform, error) {
 	// Prepare request
 	req, err := c.NewRequest("GET", "clients", nil)
 	if err != nil {
 		return nil, err
 	}
 
-	// browsersResp is a type returned by the API call for list of browsers
-	type browsersResponse struct {
-		AvailableBrowsers []Browser `json:"available_browsers"`
+	// platformsResp is a type returned by the API call for list of platforms
+	type platformsResponse struct {
+		AvailablePlatforms []Platform `json:"available_browsers"`
 	}
-	var browsersResp browsersResponse
+	var platformsResp platformsResponse
 	// Send request and process response
-	_, err = c.Do(req, &browsersResp)
+	_, err = c.Do(req, &platformsResp)
 	if err != nil {
 		return nil, err
 	}
-	return browsersResp.AvailableBrowsers, nil
+	return platformsResp.AvailablePlatforms, nil
 }
 
 // RunGroupDetails shows the details for a particular run group.

--- a/rainforest/resources_test.go
+++ b/rainforest/resources_test.go
@@ -69,7 +69,7 @@ func TestGetFolders(t *testing.T) {
 	}
 }
 
-func TestGetBrowsers(t *testing.T) {
+func TestGetPlatforms(t *testing.T) {
 	setup()
 	defer cleanup()
 
@@ -82,9 +82,9 @@ func TestGetBrowsers(t *testing.T) {
 		fmt.Fprint(w, `{"available_browsers": [{"name": "firefox", "description": "Mozilla Firefox"}]}`)
 	})
 
-	out, _ := client.GetBrowsers()
+	out, _ := client.GetPlatforms()
 
-	want := []Browser{{Name: "firefox", Description: "Mozilla Firefox"}}
+	want := []Platform{{Name: "firefox", Description: "Mozilla Firefox"}}
 
 	if !reflect.DeepEqual(out, want) {
 		t.Errorf("Response out = %v, want %v", out, want)

--- a/rainforest/rfml.go
+++ b/rainforest/rfml.go
@@ -107,19 +107,19 @@ func (r *RFMLReader) ReadAll() (*RFTest, error) {
 						strippedTags[i] = strings.TrimSpace(tag)
 					}
 					parsedRFTest.Tags = strippedTags
-				case "browsers":
+				case "platforms", "browsers":
 					// If you split the empty string instead, you will get: []string{""}
 					if len(value) == 0 {
-						parsedRFTest.Browsers = []string{}
+						parsedRFTest.Platforms = []string{}
 						continue
 					}
 
-					splitBrowsers := strings.Split(value, ",")
-					strippedBrowsers := make([]string, len(splitBrowsers))
-					for i, tag := range splitBrowsers {
-						strippedBrowsers[i] = strings.TrimSpace(tag)
+					splitPlatforms := strings.Split(value, ",")
+					strippedPlatforms := make([]string, len(splitPlatforms))
+					for i, tag := range splitPlatforms {
+						strippedPlatforms[i] = strings.TrimSpace(tag)
 					}
-					parsedRFTest.Browsers = strippedBrowsers
+					parsedRFTest.Platforms = strippedPlatforms
 				case "redirect":
 					redirect, err := strconv.ParseBool(value)
 					if err != nil {
@@ -274,11 +274,11 @@ func (r *RFMLWriter) WriteRFMLTest(test *RFTest) error {
 		}
 	}
 
-	if len(test.Browsers) > 0 {
-		browsers := strings.Join(test.Browsers, ", ")
-		browsersHeader := fmt.Sprintf("# browsers: %v\n", browsers)
+	if len(test.Platforms) > 0 {
+		platforms := strings.Join(test.Platforms, ", ")
+		platformsHeader := fmt.Sprintf("# platforms: %v\n", platforms)
 
-		_, err = writer.WriteString(browsersHeader)
+		_, err = writer.WriteString(platformsHeader)
 
 		if err != nil {
 			return err

--- a/rainforest/rfml_test.go
+++ b/rainforest/rfml_test.go
@@ -45,7 +45,7 @@ func TestReadAll(t *testing.T) {
 		State:     "enabled",
 		Priority:  "P1",
 		Tags:      []string{"foo", "bar"},
-		Browsers:  []string{"chrome", "firefox"},
+		Platforms: []string{"chrome", "firefox"},
 		Steps:     validSteps,
 		Execute:   true,
 	}
@@ -55,7 +55,7 @@ func TestReadAll(t *testing.T) {
 # start_uri: %v
 # site_id: %v
 # tags: %v
-# browsers: %v
+# platforms: %v
 # feature_id: %v
 # state: %v
 # priority: %v
@@ -72,7 +72,7 @@ func TestReadAll(t *testing.T) {
 		validTestValues.StartURI,
 		validTestValues.SiteID,
 		strings.Join(validTestValues.Tags, ", "),
-		strings.Join(validTestValues.Browsers, ", "),
+		strings.Join(validTestValues.Platforms, ", "),
 		validTestValues.FeatureID,
 		validTestValues.State,
 		validTestValues.Priority,
@@ -300,11 +300,11 @@ func TestReadAll(t *testing.T) {
 		t.Errorf("Wrong error reported. Expected error for title field. Returned error: %v", err.Error())
 	}
 
-	// empty feature_id, browser list, and tag list
+	// empty feature_id, platforms list, and tag list
 	testText = fmt.Sprintf(`#! %v
 # title: %v
 # start_uri: %v
-# browsers:
+# platforms:
 # tags:
 # feature_id:
 
@@ -324,8 +324,8 @@ func TestReadAll(t *testing.T) {
 		t.Fatalf("Unexpected error from ReadAll: %v", err.Error())
 	}
 
-	if browserCount := len(rfTest.Browsers); browserCount != 0 {
-		t.Errorf("Unexpected browsers, expected 0, got %v: %v", browserCount, rfTest.Browsers)
+	if platformCount := len(rfTest.Platforms); platformCount != 0 {
+		t.Errorf("Unexpected platforms, expected 0, got %v: %v", platformCount, rfTest.Platforms)
 	}
 
 	if tagCount := len(rfTest.Tags); tagCount != 0 {
@@ -378,7 +378,7 @@ func TestWriteRFMLTest(t *testing.T) {
 		}
 	}
 
-	mustNotHaves := []string{"site_id", "tags", "browsers", "execute"}
+	mustNotHaves := []string{"site_id", "tags", "platforms", "execute"}
 
 	for _, mustNotHave := range mustNotHaves {
 		if strings.Contains(output, mustNotHave) {
@@ -392,12 +392,12 @@ func TestWriteRFMLTest(t *testing.T) {
 	siteID := 1989
 	featureID := 2017
 	tags := []string{"foo", "bar"}
-	browsers := []string{"chrome", "firefox"}
+	platforms := []string{"chrome", "firefox"}
 	description := "This is my description\nand it spans multiple\nlines!"
 
 	test.SiteID = siteID
 	test.Tags = tags
-	test.Browsers = browsers
+	test.Platforms = platforms
 	test.Description = description
 	test.FeatureID = FeatureIDInt(featureID)
 	test.State = "disabled"
@@ -408,12 +408,12 @@ func TestWriteRFMLTest(t *testing.T) {
 	siteIDStr := "# site_id: " + strconv.Itoa(siteID)
 	featureIDStr := "# feature_id: " + strconv.Itoa(featureID)
 	tagsStr := "# tags: " + strings.Join(tags, ", ")
-	browsersStr := "# browsers: " + strings.Join(browsers, ", ")
+	platformsStr := "# platforms: " + strings.Join(platforms, ", ")
 	descStr := "# " + strings.Replace(description, "\n", "\n# ", -1)
 	stateStr := "# state: " + test.State
 	priorityStr := "# priority: " + test.Priority
 
-	mustHaves = append(mustHaves, []string{siteIDStr, featureIDStr, tagsStr, browsersStr, descStr, stateStr, priorityStr}...)
+	mustHaves = append(mustHaves, []string{siteIDStr, featureIDStr, tagsStr, platformsStr, descStr, stateStr, priorityStr}...)
 	for _, mustHave := range mustHaves {
 		if !strings.Contains(output, mustHave) {
 			t.Errorf("Missing expected string in writer output: %v", mustHave)

--- a/rainforest/runner_test.go
+++ b/rainforest/runner_test.go
@@ -61,9 +61,9 @@ func TestCreateRunFromRerun(t *testing.T) {
 
 	runParams := RunParams{
 		RunID:    runID,
-		Conflict: "abort",
+		Conflict: "cancel",
 	}
-	wantBody := `{"conflict":"abort"}`
+	wantBody := `{"conflict":"cancel"}`
 
 	mux.HandleFunc("/runs", func(w http.ResponseWriter, r *http.Request) {
 		t.Errorf("/runs endpoint hit, expected /runs/:id/rerun_failed")
@@ -171,10 +171,10 @@ func TestCreateRunFromRunGroup(t *testing.T) {
 
 	runParams := RunParams{
 		EnvironmentID: 23,
-		Conflict:      "abort",
+		Conflict:      "cancel",
 		RunGroupID:    runGroupID,
 	}
-	wantBody := `{"conflict":"abort","environment_id":23}`
+	wantBody := `{"conflict":"cancel","environment_id":23}`
 
 	mux.HandleFunc("/runs", func(w http.ResponseWriter, r *http.Request) {
 		t.Errorf("/runs endpoint hit, expected /run_groups/:id/runs")

--- a/rainforest/tests.go
+++ b/rainforest/tests.go
@@ -86,24 +86,24 @@ func (id *FeatureIDInt) MarshalJSON() ([]byte, error) {
 
 // RFTest is a struct representing the Rainforest Test with its settings and steps
 type RFTest struct {
-	TestID      int                      `json:"id"`
-	RFMLID      string                   `json:"rfml_id"`
-	Source      string                   `json:"source"`
-	Title       string                   `json:"title,omitempty"`
-	State       string                   `json:"state,omitempty"`
-	Priority    string                   `json:"priority,omitempty"`
-	StartURI    string                   `json:"start_uri"`
-	SiteID      int                      `json:"site_id,omitempty"`
-	Description string                   `json:"description,omitempty"`
-	Tags        []string                 `json:"tags"`
-	BrowsersMap []map[string]interface{} `json:"browsers"`
-	Elements    []testElement            `json:"elements,omitempty"`
-	HasWisp     bool                     `json:"has_wisp"`
-	FeatureID   FeatureIDInt             `json:"feature_id,omitempty"`
+	TestID       int                      `json:"id"`
+	RFMLID       string                   `json:"rfml_id"`
+	Source       string                   `json:"source"`
+	Title        string                   `json:"title,omitempty"`
+	State        string                   `json:"state,omitempty"`
+	Priority     string                   `json:"priority,omitempty"`
+	StartURI     string                   `json:"start_uri"`
+	SiteID       int                      `json:"site_id,omitempty"`
+	Description  string                   `json:"description,omitempty"`
+	Tags         []string                 `json:"tags"`
+	PlatformsMap []map[string]interface{} `json:"browsers"`
+	Elements     []testElement            `json:"elements,omitempty"`
+	HasWisp      bool                     `json:"has_wisp"`
+	FeatureID    FeatureIDInt             `json:"feature_id,omitempty"`
 
-	// Browsers and Steps are helper fields
-	Browsers []string      `json:"-"`
-	Steps    []interface{} `json:"-"`
+	// Platforms and Steps are helper fields
+	Platforms []string      `json:"-"`
+	Steps     []interface{} `json:"-"`
 	// RFMLPath is a helper field for keeping track of the filepath to the
 	// test's RFML file.
 	RFMLPath string `json:"-"`
@@ -129,24 +129,24 @@ type testElementDetails struct {
 	Elements []testElement `json:"elements,omitempty"` // for embedded tests
 }
 
-// mapBrowsers fills the browsers field with format recognized by the API
-func (t *RFTest) mapBrowsers() {
-	t.BrowsersMap = make([]map[string]interface{}, len(t.Browsers))
-	for i, browser := range t.Browsers {
-		mappedBrowser := map[string]interface{}{
+// mapPlatforms fills the browsers field with format recognized by the API
+func (t *RFTest) mapPlatforms() {
+	t.PlatformsMap = make([]map[string]interface{}, len(t.Platforms))
+	for i, platform := range t.Platforms {
+		mappedPlatform := map[string]interface{}{
 			"state": "enabled",
-			"name":  browser,
+			"name":  platform,
 		}
-		t.BrowsersMap[i] = mappedBrowser
+		t.PlatformsMap[i] = mappedPlatform
 	}
 }
 
-// unmapBrowsers parses browsers from the API format to internal go one
-func (t *RFTest) unmapBrowsers() {
-	t.Browsers = []string{}
-	for _, browserMap := range t.BrowsersMap {
-		if browserMap["state"] == "enabled" {
-			t.Browsers = append(t.Browsers, browserMap["name"].(string))
+// unmapPlatforms parses browsers from the API format to internal go one
+func (t *RFTest) unmapPlatforms() {
+	t.Platforms = []string{}
+	for _, platformMap := range t.PlatformsMap {
+		if platformMap["state"] == "enabled" {
+			t.Platforms = append(t.Platforms, platformMap["name"].(string))
 		}
 	}
 }
@@ -238,7 +238,7 @@ func (t *RFTest) PrepareToUploadFromRFML(coll TestIDCollection) error {
 		t.Tags = []string{}
 	}
 
-	t.mapBrowsers()
+	t.mapPlatforms()
 	err := t.marshallElements(coll)
 	if err != nil {
 		return err
@@ -252,7 +252,7 @@ func (t *RFTest) PrepareToWriteAsRFML(coll TestIDCollection, flattenedSteps bool
 	if err != nil {
 		return err
 	}
-	t.unmapBrowsers()
+	t.unmapPlatforms()
 	return nil
 }
 

--- a/rainforest/tests_test.go
+++ b/rainforest/tests_test.go
@@ -14,7 +14,7 @@ import (
 func TestPrepareToWriteAsRFML(t *testing.T) {
 	test := RFTest{
 		StartURI: "",
-		BrowsersMap: []map[string]interface{}{
+		PlatformsMap: []map[string]interface{}{
 			{
 				"name":  "foo",
 				"state": "enabled",
@@ -76,9 +76,9 @@ func TestPrepareToWriteAsRFML(t *testing.T) {
 		t.Fatal(err.Error())
 	}
 
-	expectedBrowsers := []string{"foo", "baz"}
-	if !reflect.DeepEqual(test.Browsers, expectedBrowsers) {
-		t.Errorf("Expected browsers to be %v, got %v", expectedBrowsers, test.Browsers)
+	expectedPlatforms := []string{"foo", "baz"}
+	if !reflect.DeepEqual(test.Platforms, expectedPlatforms) {
+		t.Errorf("Expected browsers to be %v, got %v", expectedPlatforms, test.Platforms)
 	}
 
 	if len(test.Steps) != 3 {
@@ -441,13 +441,13 @@ func TestUpdateTest(t *testing.T) {
 	}
 
 	// // With extra attributes
-	rfTest.Browsers = []string{"chrome", "firefox"}
+	rfTest.Platforms = []string{"chrome", "firefox"}
 	rfTest.Tags = []string{"foo", "bar"}
 	rfTest.FeatureID = 909
 	rfTest.State = "disabled"
 	rfTest.Priority = "P1"
 
-	rfTest.mapBrowsers()
+	rfTest.mapPlatforms()
 
 	cleanup()
 	setup()
@@ -490,9 +490,9 @@ func TestUpdateTest(t *testing.T) {
 
 	// Deleted feature ID, empty browsers and tags list
 	rfTest.FeatureID = deleteFeature
-	rfTest.Browsers = []string{}
+	rfTest.Platforms = []string{}
 	rfTest.Tags = []string{}
-	rfTest.mapBrowsers()
+	rfTest.mapPlatforms()
 
 	cleanup()
 	setup()

--- a/resources.go
+++ b/resources.go
@@ -29,7 +29,7 @@ func printResourceTable(headers []string, rows [][]string) {
 // resourceAPI is part of the API connected to available resources
 type resourceAPI interface {
 	GetFolders() ([]rainforest.Folder, error)
-	GetBrowsers() ([]rainforest.Browser, error)
+	GetPlatforms() ([]rainforest.Platform, error)
 	GetSites() ([]rainforest.Site, error)
 	GetEnvironments() ([]rainforest.Environment, error)
 	GetFeatures() ([]rainforest.Feature, error)
@@ -54,20 +54,20 @@ func printFolders(api resourceAPI) error {
 	return nil
 }
 
-// printBrowsers fetches and prints out the browsers available to the client
-func printBrowsers(api resourceAPI) error {
-	// Fetch the list of browsers from the Rainforest
-	browsers, err := api.GetBrowsers()
+// printPlatforms fetches and prints out the platforms available to the client
+func printPlatforms(api resourceAPI) error {
+	// Fetch the list of platforms from the Rainforest
+	platforms, err := api.GetPlatforms()
 	if err != nil {
 		return cli.NewExitError(err.Error(), 1)
 	}
 
-	rows := make([][]string, len(browsers))
-	for i, browser := range browsers {
-		rows[i] = []string{browser.Name, browser.Description}
+	rows := make([][]string, len(platforms))
+	for i, platform := range platforms {
+		rows[i] = []string{platform.Name, platform.Description}
 	}
 
-	printResourceTable([]string{"Browser ID", "Browser Name"}, rows)
+	printResourceTable([]string{"Platform ID", "Platform Name"}, rows)
 	return nil
 }
 

--- a/resources_test.go
+++ b/resources_test.go
@@ -35,7 +35,7 @@ func TestPrintResourceTable(t *testing.T) {
 
 type testResourceAPI struct {
 	Folders      []rainforest.Folder
-	Browsers     []rainforest.Browser
+	Platforms    []rainforest.Platform
 	Sites        []rainforest.Site
 	Environments []rainforest.Environment
 	Features     []rainforest.Feature
@@ -47,8 +47,8 @@ func (api testResourceAPI) GetFolders() ([]rainforest.Folder, error) {
 	return api.Folders, nil
 }
 
-func (api testResourceAPI) GetBrowsers() ([]rainforest.Browser, error) {
-	return api.Browsers, nil
+func (api testResourceAPI) GetPlatforms() ([]rainforest.Platform, error) {
+	return api.Platforms, nil
 }
 
 func (api testResourceAPI) GetSites() ([]rainforest.Site, error) {
@@ -90,21 +90,21 @@ func TestPrintFolders(t *testing.T) {
 	regexMatchOut(`\| +456 +\| +Second Folder Title +\|`, t)
 }
 
-func TestPrintBrowsers(t *testing.T) {
+func TestPrintPlatforms(t *testing.T) {
 	tablesOut = &bytes.Buffer{}
 	defer func() {
 		tablesOut = os.Stdout
 	}()
 
 	testAPI := testResourceAPI{
-		Browsers: []rainforest.Browser{
+		Platforms: []rainforest.Platform{
 			{Name: "chrome", Description: "Google Chrome"},
 			{Name: "firefox", Description: "Mozilla Firefox"},
 		},
 	}
 
-	printBrowsers(testAPI)
-	regexMatchOut(`\| +BROWSER ID +\| +BROWSER NAME +\|`, t)
+	printPlatforms(testAPI)
+	regexMatchOut(`\| +PLATFORM ID +\| +PLATFORM NAME +\|`, t)
 	regexMatchOut(`\| +chrome +\| +Google Chrome +\|`, t)
 	regexMatchOut(`\| +firefox +\| +Mozilla Firefox +\|`, t)
 }

--- a/runner.go
+++ b/runner.go
@@ -393,8 +393,7 @@ func (r *runner) makeRunParams(c cliContext, localTests []*rainforest.RFTest) (r
 	featureID := c.Int("feature")
 	runGroupID := c.Int("run-group")
 
-	browsers := c.StringSlice("browser")
-	expandedBrowsers := expandStringSlice(browsers)
+	platforms := getPlatforms(c)
 
 	description := c.String("description")
 	release := c.String("release")
@@ -459,7 +458,7 @@ func (r *runner) makeRunParams(c cliContext, localTests []*rainforest.RFTest) (r
 		SiteID:               siteID,
 		Crowd:                crowd,
 		Conflict:             conflict,
-		Browsers:             expandedBrowsers,
+		Browsers:             platforms,
 		Description:          description,
 		Release:              release,
 		EnvironmentID:        environmentID,
@@ -518,6 +517,17 @@ func stringToIntSlice(s string) ([]int, error) {
 func getTags(c cliContext) []string {
 	tags := c.StringSlice("tag")
 	return expandStringSlice(tags)
+}
+
+func getPlatforms(c cliContext) []string {
+	var platforms []string
+	if platforms = c.StringSlice("browser"); len(platforms) > 0 {
+		fmt.Println("RF CLI Deprecation: --browser(s) is deprecated, use --platform (or --platforms) instead")
+	} else {
+		platforms = c.StringSlice("platform")
+	}
+
+	return expandStringSlice(platforms)
 }
 
 // getConflict gets conflict from a CLI context. It returns an error if value isn't allowed

--- a/runner.go
+++ b/runner.go
@@ -523,7 +523,7 @@ func getTags(c cliContext) []string {
 // getConflict gets conflict from a CLI context. It returns an error if value isn't allowed
 func getConflict(c cliContext) (string, error) {
 	var conflict string
-	if conflict = c.String("conflict"); conflict != "" && conflict != "abort" && conflict != "abort-all" {
+	if conflict = c.String("conflict"); conflict != "" && conflict != "abort" && conflict != "abort-all" && conflict != "cancel" && conflict != "cancel-all" {
 		return "", errors.New("Invalid conflict option specified")
 	}
 

--- a/runner_test.go
+++ b/runner_test.go
@@ -187,7 +187,7 @@ func TestMakeRunParams(t *testing.T) {
 				"folder":         "123",
 				"site":           "456",
 				"crowd":          "on_premise_crowd",
-				"conflict":       "abort",
+				"conflict":       "cancel",
 				"browser":        []string{"chrome", "firefox,safari"},
 				"description":    "my awesome description",
 				"release":        "1a2b3c",
@@ -199,7 +199,7 @@ func TestMakeRunParams(t *testing.T) {
 				SmartFolderID: 123,
 				SiteID:        456,
 				Crowd:         "on_premise_crowd",
-				Conflict:      "abort",
+				Conflict:      "cancel",
 				Browsers:      []string{"chrome", "firefox", "safari"},
 				Description:   "my awesome description",
 				Release:       "1a2b3c",
@@ -305,12 +305,12 @@ func TestMakeRerunParams(t *testing.T) {
 		},
 		{
 			mappings: map[string]interface{}{
-				"conflict": "abort",
+				"conflict": "cancel",
 			},
 			args: cli.Args{"82"},
 			expected: rainforest.RunParams{
 				RunID:    82,
-				Conflict: "abort",
+				Conflict: "cancel",
 			},
 		},
 	}

--- a/runner_test.go
+++ b/runner_test.go
@@ -188,7 +188,7 @@ func TestMakeRunParams(t *testing.T) {
 				"site":           "456",
 				"crowd":          "on_premise_crowd",
 				"conflict":       "cancel",
-				"browser":        []string{"chrome", "firefox,safari"},
+				"platform":       []string{"chrome", "firefox,safari"},
 				"description":    "my awesome description",
 				"release":        "1a2b3c",
 				"environment-id": "1337",


### PR DESCRIPTION
Rename certain things to match their in-app name, while maintaining support for the legacy names.

#### Changes
- `rainforest run --conflict abort[-all]` => `rainforest run --conflict cancel[-all]`
- `rainforest browsers` => `rainforest platforms`
- `rainforest run --browser[s] chrome,firefox` => `rainforest-run --platform[s] chrome,firefox`
- RFML: `# browsers: chrome,firefox` => `# platforms: chrome,firefox`

#### Testing deprecation warning from API (returned via custom HTTP header)
```
> ./build/rainforest --skip-update run --run-group 9502 --conflict abort
RF API Deprecation: abort is deprecated; use cancel instead
2022/03/16 14:53:20 Run 882659 has been created. The detailed results are available at https://app.rainforestqa.com/runs/882659
```
