### PR TITLE
[RF-24889] Add `--execution-method` flag, deprecate `--crowd`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 # Rainforest CLI Changelog
+## 3.1.0 - 2022-09-20
+- Update output of `run-groups` command to show execution method rather than crowd
+  - (7198e7c0835dc68ee02c03c7be6ed22e0b7c0edb, @magni-)
+- Add `--execution-method` flag to `run` command, deprecate `--crowd` flag it replaces
+  - (0515241776b4252888ed8c2302ff50359e5c5a4e, @magni-)
+
 ## 3.0.0 - 2022-09-01
 - Drop support for deprecated `abort` and `abort-all` options for `--conflict` flag
   - (33912ac48263de45a6d8ce5a62c75818be748b96, @magni-)

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ rainforest run <test_id1> <test_id2>
 
 Run a run group.
 
-⚠️ This uses the configuration defined in the run group (environment, platforms, crowd, location). If you wish to run tests from a run group without using the run group's configuration, you will need to use the Rainforest API directly, passing a `run_group_id` parameter to [the `POST /runs` endpoint](https://help.rainforestqa.com/reference/post-runs). ⚠️
+⚠️ This uses the configuration defined in the run group (environment, platforms, execution method, location). If you wish to run tests from a run group without using the run group's configuration, you will need to use the Rainforest API directly, passing a `run_group_id` parameter to [the `POST /runs` endpoint](https://help.rainforestqa.com/reference/post-runs). ⚠️
 
 ```bash
 rainforest run --run-group <run_group_id>
@@ -344,7 +344,7 @@ Popular command line options are:
 - `--environment-id` - run your tests using this environment. Otherwise it will use your default environment
 - `--conflict OPTION` - use the `cancel` option to cancel any runs in progress in the same environment as your new run. Use the `cancel-all` option to cancel all runs in progress.
 - `--bg` - creates a run in the background and rainforest-cli exits immediately after. Do not use if you want rainforest-cli to track your run and exit with an error code upon run failure (ie: using Rainforest in your CI environment). Cannot be used together with `--max-reruns`.
-- `--crowd [default|automation|automation_and_crowd|on_premise_crowd]` - select automation or your crowd of testers (for clients with on premise testers). For more information, contact us at help@rainforestqa.com.
+- `--execution-method [crowd|automation|automation_and_crowd|on_premise]` - select how you wish your tests to be run. Your account may not have access to all methods. For more information, contact us at help@rainforestqa.com.
 - `--wait RUN_ID` - wait for an existing run to finish instead of starting a new one, and exit with a non-0 code if the run fails. rainforest-cli will exit immediately if the run is already complete.
 - `--fail-fast` - return an error as soon as the first failed result comes in (the run always proceeds until completion, but the CLI will return an error code early). If you don't use it, it will wait until 100% of the run is done. Has no effect with `--bg` and cannot be used together with `--max-reruns`.
 - `--custom-url` - specify the URL for the run to use when testing against an ephemeral environment. This will create a new temporary environment for the run. Temporary environments will be automatically deleted 72 hours after they were last used.

--- a/rainforest-cli.go
+++ b/rainforest-cli.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	// Version of the app in SemVer
-	version = "3.0.0"
+	version = "3.1.0"
 	// This is the default spec folder for RFML tests
 	defaultSpecFolder = "./spec/rainforest"
 )

--- a/rainforest-cli.go
+++ b/rainforest-cli.go
@@ -206,9 +206,13 @@ func main() {
 					Usage: "Run your tests using specified `ENVIRONMENT`. Otherwise it will use your default one.",
 				},
 				cli.StringFlag{
-					Name: "crowd",
-					Usage: "Run your tests using specified `CROWD`. Available choices are: default, automation, automation_and_crowd " +
-						"or on_premise_crowd. Contact your CSM for more details.",
+					Name: "execution-method",
+					Usage: "Run your tests using specified `EXECUTION_METHOD`. Available choices are: crowd, automation, automation_and_crowd, " +
+						"and on_premise. Some methods may not be available for your account. For more information, contact us at help@rainforestqa.com.",
+				},
+				cli.StringFlag{
+					Name:  "crowd",
+					Usage: "DEPRECATED: Use --execution-method instead",
 				},
 				cli.StringFlag{
 					Name: "conflict",

--- a/rainforest/rainforest.go
+++ b/rainforest/rainforest.go
@@ -84,7 +84,7 @@ func (c *Client) ClientToken() string {
 // NewRequest creates an API request. Provided url will be resolved using ResolveReference,
 // which works in a similar way to the hrefs in a browser (most important takeaway is to
 // not add preceeding slash to the link as it resolves to a root path of domain).
-// The body argument is JSON endoded and attached as a request body.
+// The body argument is JSON encoded and attached as a request body.
 // This function also attaches auth token from the client to the request.
 func (c *Client) NewRequest(method, urlStr string, body interface{}) (*http.Request, error) {
 	// Resolve the relative URL path

--- a/rainforest/resources.go
+++ b/rainforest/resources.go
@@ -107,9 +107,9 @@ func (c *Client) GetPlatforms() ([]Platform, error) {
 
 // RunGroupDetails shows the details for a particular run group.
 type RunGroupDetails struct {
-	ID              int    `json:"id"`
-	Title           string `json:"title"`
-	Environment     struct {
+	ID          int    `json:"id"`
+	Title       string `json:"title"`
+	Environment struct {
 		Name string `json:"name"`
 	} `json:"environment"`
 	ExecutionMethod string `json:"execution_method"`

--- a/rainforest/resources.go
+++ b/rainforest/resources.go
@@ -107,14 +107,14 @@ func (c *Client) GetPlatforms() ([]Platform, error) {
 
 // RunGroupDetails shows the details for a particular run group.
 type RunGroupDetails struct {
-	ID          int    `json:"id"`
-	Title       string `json:"title"`
-	Environment struct {
+	ID              int    `json:"id"`
+	Title           string `json:"title"`
+	Environment     struct {
 		Name string `json:"name"`
 	} `json:"environment"`
-	Crowd      string `json:"crowd"`
-	RerouteGeo string `json:"reroute_geo"`
-	Schedule   struct {
+	ExecutionMethod string `json:"execution_method"`
+	RerouteGeo      string `json:"reroute_geo"`
+	Schedule        struct {
 		RepeatRules []struct {
 			Day  string `json:"day"`
 			Time string `json:"time"`
@@ -127,10 +127,10 @@ func (rgd *RunGroupDetails) Print() {
 	fmt.Printf(`Details for Run Group #%v:
 Name: %v
 Environment: %v
-Tester Crowd: %v
+Execution Method: %v
 Location: %v
 `,
-		rgd.ID, rgd.Title, rgd.Environment.Name, rgd.Crowd, rgd.RerouteGeo)
+		rgd.ID, rgd.Title, rgd.Environment.Name, rgd.ExecutionMethod, rgd.RerouteGeo)
 	sched := rgd.Schedule
 
 	if daysQuantity := len(sched.RepeatRules); daysQuantity > 0 {

--- a/rainforest/runner.go
+++ b/rainforest/runner.go
@@ -14,7 +14,7 @@ type RunParams struct {
 	Tags                 []string    `json:"tags,omitempty"`
 	SmartFolderID        int         `json:"smart_folder_id,omitempty"`
 	SiteID               int         `json:"site_id,omitempty"`
-	Crowd                string      `json:"crowd,omitempty"`
+	ExecutionMethod      string      `json:"execution_method,omitempty"`
 	Conflict             string      `json:"conflict,omitempty"`
 	Browsers             []string    `json:"browsers,omitempty"`
 	Description          string      `json:"description,omitempty"`
@@ -94,8 +94,8 @@ func validateRerunParams(params RunParams) error {
 	if params.SiteID != 0 {
 		return errors.New("Site cannot be specified for rerun")
 	}
-	if params.Crowd != "" {
-		return errors.New("Crowd cannot be specified for rerun")
+	if params.ExecutionMethod != "" {
+		return errors.New("Execution Method cannot be specified for rerun")
 	}
 	if params.Browsers != nil {
 		return errors.New("Browsers cannot be specified for rerun")

--- a/rainforest/runner_test.go
+++ b/rainforest/runner_test.go
@@ -118,8 +118,8 @@ func TestCreateRunFromRerun(t *testing.T) {
 			RFMLIDs: []string{"rmfl1"},
 		},
 		{
-			RunID: runID,
-			Crowd: "automation",
+			RunID:           runID,
+			ExecutionMethod: "automation",
 		},
 		{
 			RunID:       runID,

--- a/runner_test.go
+++ b/runner_test.go
@@ -196,16 +196,16 @@ func TestMakeRunParams(t *testing.T) {
 			},
 			args: cli.Args{"12", "34", "56, 78"},
 			expected: rainforest.RunParams{
-				SmartFolderID: 123,
-				SiteID:        456,
-				Crowd:         "on_premise_crowd",
-				Conflict:      "cancel",
-				Browsers:      []string{"chrome", "firefox", "safari"},
-				Description:   "my awesome description",
-				Release:       "1a2b3c",
-				EnvironmentID: 1337,
-				Tags:          []string{"tag", "tag2", "tag3"},
-				Tests:         []int{12, 34, 56, 78},
+				SmartFolderID:   123,
+				SiteID:          456,
+				ExecutionMethod: "on_premise",
+				Conflict:        "cancel",
+				Browsers:        []string{"chrome", "firefox", "safari"},
+				Description:     "my awesome description",
+				Release:         "1a2b3c",
+				EnvironmentID:   1337,
+				Tags:            []string{"tag", "tag2", "tag3"},
+				Tests:           []int{12, 34, 56, 78},
 			},
 		},
 		{
@@ -244,18 +244,18 @@ func TestMakeRunParams(t *testing.T) {
 		},
 		{
 			mappings: map[string]interface{}{
-				"crowd": "automation",
+				"execution-method": "automation",
 			},
 			expected: rainforest.RunParams{
-				Crowd: "automation",
+				ExecutionMethod: "automation",
 			},
 		},
 		{
 			mappings: map[string]interface{}{
-				"crowd": "automation_and_crowd",
+				"execution-method": "automation_and_crowd",
 			},
 			expected: rainforest.RunParams{
-				Crowd: "automation_and_crowd",
+				ExecutionMethod: "automation_and_crowd",
 			},
 		},
 	}


### PR DESCRIPTION
Regardless of which flag users use, we'll send `execution_method` to the backend.

This PR also updates the output of the `run_groups` command to show the execution method rather than the crowd.