### PR TITLE
RF-24826 Add snippet support to RFML files

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,7 @@ Rainforest Tests written using RFML have the following format
 # platforms: [PLATFORM IDS]
 # feature_id: [FEATURE_ID]
 # state: [STATE]
+# type: [TYPE]
 # [OTHER COMMENTS]
 
 [ACTION 1]
@@ -304,6 +305,11 @@ be a UUID, but you are free to change it for easier reference (for example, your
 login test might have the id `login_test`).
 - `TITLE` - The title of your test.
 - `START_URI` - The path used to direct the tester to the correct page to begin the test.
+- `TYPE` - The type of test represented. Must be one of either `test` for regular, top-level
+tests or `snippet` for any test that is meant to be embedded within another test. In other
+words, if you're going to execute the test directly, it should be of type `test`; if you're
+going to refer to it from another file (via a `- [EMBEDDED TEST RFML ID]` directive) it should
+be of type `snippet`.
 - `ACTION 1`, `ACTION 2`, ... - The directions for your tester to follow in this
 step. You must have at least one step in your test.
 - `QUESTION 1`, `QUESTION 2`, ... - The question you would like your tester to

--- a/rainforest/rfml.go
+++ b/rainforest/rfml.go
@@ -274,6 +274,14 @@ func (r *RFMLWriter) WriteRFMLTest(test *RFTest) error {
 		}
 	}
 
+	if test.Type != "" {
+		_, err = writer.WriteString("# type: " + test.Type)
+
+		if err != nil {
+			return err
+		}
+	}
+
 	if len(test.Platforms) > 0 {
 		platforms := strings.Join(test.Platforms, ", ")
 		platformsHeader := fmt.Sprintf("# platforms: %v\n", platforms)

--- a/rainforest/rfml.go
+++ b/rainforest/rfml.go
@@ -277,7 +277,7 @@ func (r *RFMLWriter) WriteRFMLTest(test *RFTest) error {
 	}
 
 	if test.Type != "" {
-		_, err = writer.WriteString("# type: " + test.Type)
+		_, err = writer.WriteString("# type: " + test.Type + "\n")
 
 		if err != nil {
 			return err

--- a/rainforest/rfml.go
+++ b/rainforest/rfml.go
@@ -15,7 +15,7 @@ import (
 	"strings"
 )
 
-// RFMLReader reads form RFML formatted file.
+// RFMLReader reads from an RFML formatted file.
 // It exports some settings that can be set before parsing.
 type RFMLReader struct {
 	r *bufio.Reader
@@ -154,6 +154,8 @@ func (r *RFMLReader) ReadAll() (*RFTest, error) {
 						return parsedRFTest, &parseError{lineNumStr, "Execute value must be a valid boolean"}
 					}
 					parsedRFTest.Execute = execute
+				case "type":
+					parsedRFTest.Type = value
 				default:
 					// If it doesn't match known key add it to description
 					parsedRFTest.Description += strings.TrimSpace(content) + "\n"

--- a/rainforest/rfml_test.go
+++ b/rainforest/rfml_test.go
@@ -182,6 +182,29 @@ func TestReadAll(t *testing.T) {
 		t.Errorf("Incorrect test priority. Got %v, Want empty string", rfTest.Priority)
 	}
 
+	// Test type is present
+	testText = fmt.Sprintf(`#! %v
+# title: %v
+# start_uri: %v
+# type: %v
+`,
+		validTestValues.RFMLID,
+		validTestValues.Title,
+		validTestValues.StartURI,
+		"test",
+	)
+
+	r = strings.NewReader(testText)
+	reader = NewRFMLReader(r)
+	rfTest, err = reader.ReadAll()
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	if rfTest.Type != "test" {
+		t.Errorf("Incorrect test type. Got %v, Want %v", rfTest.Type, "'test'")
+	}
+
 	// Comment with a colon
 	expectedComment := "this_should: be a comment"
 	testText = fmt.Sprintf(`#! %v

--- a/rainforest/rfml_test.go
+++ b/rainforest/rfml_test.go
@@ -345,12 +345,14 @@ func TestWriteRFMLTest(t *testing.T) {
 	rfmlID := "fake_rfml_id"
 	title := "fake_title"
 	startURI := "/path/to/nowhere"
+	testType := "snippet"
 
 	test := RFTest{
 		RFMLID:   rfmlID,
 		Title:    title,
 		StartURI: startURI,
 		Execute:  true,
+		Type:     testType,
 	}
 
 	getOutput := func() string {
@@ -412,8 +414,9 @@ func TestWriteRFMLTest(t *testing.T) {
 	descStr := "# " + strings.Replace(description, "\n", "\n# ", -1)
 	stateStr := "# state: " + test.State
 	priorityStr := "# priority: " + test.Priority
+	typeStr := "# type: " + test.Type
 
-	mustHaves = append(mustHaves, []string{siteIDStr, featureIDStr, tagsStr, platformsStr, descStr, stateStr, priorityStr}...)
+	mustHaves = append(mustHaves, []string{siteIDStr, featureIDStr, tagsStr, platformsStr, descStr, stateStr, priorityStr, typeStr}...)
 	for _, mustHave := range mustHaves {
 		if !strings.Contains(output, mustHave) {
 			t.Errorf("Missing expected string in writer output: %v", mustHave)

--- a/rainforest/tests.go
+++ b/rainforest/tests.go
@@ -100,6 +100,7 @@ type RFTest struct {
 	Elements     []testElement            `json:"elements,omitempty"`
 	HasWisp      bool                     `json:"has_wisp"`
 	FeatureID    FeatureIDInt             `json:"feature_id,omitempty"`
+	Type         string                   `json:"type"`
 
 	// Platforms and Steps are helper fields
 	Platforms []string      `json:"-"`

--- a/tests.go
+++ b/tests.go
@@ -276,6 +276,7 @@ func newRFMLTest(c cliContext) error {
 		RFMLID:   uuid.NewV4().String(),
 		Title:    title,
 		StartURI: "/",
+		Type:     "test",
 		Execute:  true,
 		Steps: []interface{}{
 			rainforest.RFTestStep{

--- a/tests.go
+++ b/tests.go
@@ -405,6 +405,7 @@ func uploadSingleRFMLFile(filePath string) error {
 		emptyTest := rainforest.RFTest{
 			RFMLID: parsedTest.RFMLID,
 			Title:  parsedTest.Title,
+			Type:   parsedTest.Type,
 		}
 
 		err = emptyTest.PrepareToUploadFromRFML(*testIDCollection)

--- a/tests_test.go
+++ b/tests_test.go
@@ -325,6 +325,7 @@ func TestUploadTests(t *testing.T) {
 	testID := 666
 	rfmlID := "unique_rfml_id"
 	title := "a very descriptive title"
+	testType := "test"
 	var featureID rainforest.FeatureIDInt = 777
 
 	err := createTestFolder(testDefaultSpecFolder)
@@ -346,6 +347,7 @@ func TestUploadTests(t *testing.T) {
 			{"test ID", testID, rfTest.TestID},
 			{"RFML ID", rfmlID, rfTest.RFMLID},
 			{"title", title, rfTest.Title},
+			{"test type", testType, rfTest.Type},
 			{"feature ID", featureID, rfTest.FeatureID},
 			{"disabled state", "enabled", rfTest.State},
 		}
@@ -360,7 +362,8 @@ func TestUploadTests(t *testing.T) {
 	testContents := fmt.Sprintf(`#! %v
 # title: %v
 # feature_id: %v
-`, rfmlID, title, featureID)
+# type: %v
+`, rfmlID, title, featureID, testType)
 
 	err = ioutil.WriteFile(testPath, []byte(testContents), os.ModePerm)
 	if err != nil {


### PR DESCRIPTION
Edit: I just marked this as DNM because we don't want this released until we coordinate with Domino on a time that works for them. As of this moment @pyromaniackeca has been asked to shepherd this release out when it makes sense to do so.

Adds support for downloading and uploading tests and snippets via RFML. This introduces a new RFML field `type` that can be either `test` for top-level tests or `snippet` for the new reusable snippet-type tests (formerly "embedded tests").

* Running `rainforest download` will make sure all existing tests have their `type` set correctly.
* Running `rainforest new` will generate a new RFML file with its `type` set to `test`. You can manually change that to `snippet` if you need to embed it in another test/snippet.
* Running `rainforest upload` will update the tests as usual and create any tests / snippets depending on their type. Note: changing the `type` in the RFML file is not supported. The rest of test will still get updated correctly but its type will not change.
