### PR TITLE
[RF-25598] Reuse existing description when overwriting an existing generator

### DIFF
--- a/rainforest/tabularvars.go
+++ b/rainforest/tabularvars.go
@@ -19,16 +19,6 @@ type Generator struct {
 	RowCount    int               `json:"row_count,omitempty"`
 }
 
-// GetID returns the Generator name
-func (g Generator) GetID() string {
-	return g.Name
-}
-
-// GetDescription returns the Generator's description
-func (g Generator) GetDescription() string {
-	return g.Description
-}
-
 // GeneratorColumn is a type of column in a generator
 type GeneratorColumn struct {
 	ID        int       `json:"id,omitempty"`

--- a/tabularvars.go
+++ b/tabularvars.go
@@ -43,6 +43,7 @@ func uploadTabularVar(api tabularVariablesAPI, pathToCSV, name string, overwrite
 
 	// Check if the variable exists in RF
 	var existingGenID int
+	var description string
 	generators, err := api.GetGenerators()
 	if err != nil {
 		return err
@@ -51,6 +52,7 @@ func uploadTabularVar(api tabularVariablesAPI, pathToCSV, name string, overwrite
 	for _, gen := range generators {
 		if gen.Name == name {
 			existingGenID = gen.ID
+			description = gen.Description
 		}
 	}
 
@@ -67,6 +69,8 @@ func uploadTabularVar(api tabularVariablesAPI, pathToCSV, name string, overwrite
 			return errors.New("Tabular variable: " + name +
 				" already exists, use different name or choose an option to override it")
 		}
+	} else {
+		description = "Uploaded via the CLI"
 	}
 
 	// prepare input data
@@ -79,7 +83,6 @@ func uploadTabularVar(api tabularVariablesAPI, pathToCSV, name string, overwrite
 	}
 
 	// create new generator for the tabular variable
-	description := "Variable " + name + " uploded through cli client."
 	newGenerator, err := api.CreateTabularVar(name, description, parsedColumnNames, singleUse)
 	if err != nil {
 		return err

--- a/tabularvars_test.go
+++ b/tabularvars_test.go
@@ -409,6 +409,7 @@ func TestUploadTabularVar_Exists_Overwrite(t *testing.T) {
 	defer deleteFakeCSV(t)
 	tabularBatchSize = 2
 	variableName := "testVar"
+	variableDescription := "testVar description"
 	variableOverwrite := true
 	variableSingleUse := false
 	// Data from csv
@@ -417,8 +418,9 @@ func TestUploadTabularVar_Exists_Overwrite(t *testing.T) {
 	secondBatch := [][]string{{"qwe", "asd"}, {"zxc", "jkl"}}
 	// Fake responses Data
 	fakeNewGen := rainforest.Generator{
-		ID:   123,
-		Name: variableName,
+		ID:          123,
+		Name:        variableName,
+		Description: variableDescription,
 		Columns: []rainforest.GeneratorColumn{
 			{
 				ID:   456,
@@ -474,6 +476,9 @@ func TestUploadTabularVar_Exists_Overwrite(t *testing.T) {
 			singleUse bool) (*rainforest.Generator, error) {
 			if variableName != name {
 				t.Errorf("Incorrect value of name passed to newTabVar. Got: %v, expected: %v", name, variableName)
+			}
+			if variableDescription != description {
+				t.Errorf("Incorrect value of description passed to newTabVar. Got: %v, expected: %v", description, variableDescription)
 			}
 			if !reflect.DeepEqual(columns, cols) {
 				t.Errorf("Incorrect value of columns passed to newTabVar. Got: %v, expected: %v", columns, cols)


### PR DESCRIPTION
We'll want to update the wording everywhere to match what's in the webapp ("Test Data" rather than "Tabular Variable"), but this is just a quick fix so we don't clobber an existing description when updating an existing generator.