### PR TITLE
[RF-25461] Add branching support to rainforest CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,12 @@ Run individual tests in the foreground and report.
 rainforest run <test_id1> <test_id2>
 ```
 
+Run all tests on a branch.
+
+```bash
+rainforest run all --branch branch-name
+```
+
 Run a run group.
 
 ⚠️ This uses the configuration defined in the run group (environment, platforms, execution method, location). If you wish to run tests from a run group without using the run group's configuration, you will need to use the Rainforest API directly, passing a `run_group_id` parameter to [the `POST /runs` endpoint](https://help.rainforestqa.com/reference/post-runs). ⚠️
@@ -156,6 +162,12 @@ Upload a specific test to Rainforest
 
 ```bash
 rainforest upload /path/to/test/file.rfml
+```
+
+Upload a specific test to Rainforest on a branch
+
+```bash
+rainforest upload --branch branch-name /path/to/test/file.rfml
 ```
 
 Remove RFML file and remove test from Rainforest test suite.
@@ -249,6 +261,23 @@ rainforest csv-upload --import-variable-name my_variable PATH/TO/CSV.csv
 Upload a CSV to update an existing tabular variables.
 ```bash
 rainforest csv-upload --import-variable-name my_variable --overwrite-variable PATH/TO/CSV.csv
+```
+
+#### Managing branches
+
+Create a new branch.
+```bash
+rainforest branch new branch-name
+```
+
+Delete an existing branch.
+```bash
+rainforest branch delete branch-name
+```
+
+Merge an existing branch into the `main` branch.
+```bash
+rainforest branch merge branch-name
 ```
 
 #### Uploading Mobile Apps

--- a/branches.go
+++ b/branches.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/rainforestapp/rainforest-cli/rainforest"
+	"github.com/urfave/cli"
+)
+
+type branchAPI interface {
+	CreateBranch(*rainforest.Branch) error
+}
+
+func newBranch(c cliContext, api branchAPI) error {
+	name := c.Args().First()
+	name = strings.TrimSpace(name)
+
+	if name == "" {
+		return cli.NewExitError("Branch name cannot be blank", 1)
+	}
+
+	branch := rainforest.Branch{
+		Name: name,
+	}
+
+	err := api.CreateBranch(&branch)
+
+	if err != nil {
+		return cli.NewExitError(err.Error(), 1)
+	}
+
+	fmt.Printf("Created branch %q.\n", name)
+	return nil
+}

--- a/branches.go
+++ b/branches.go
@@ -9,7 +9,9 @@ import (
 )
 
 type branchAPI interface {
+	GetBranches(...string) ([]rainforest.Branch, error)
 	CreateBranch(*rainforest.Branch) error
+	DeleteBranch(int) error
 }
 
 func newBranch(c cliContext, api branchAPI) error {
@@ -31,5 +33,35 @@ func newBranch(c cliContext, api branchAPI) error {
 	}
 
 	fmt.Printf("Created branch %q.\n", name)
+	return nil
+}
+
+func deleteBranch(c cliContext, api branchAPI) error {
+	name := c.Args().First()
+	name = strings.TrimSpace(name)
+
+	if name == "" {
+		return cli.NewExitError("Branch name cannot be blank", 1)
+	}
+
+	branches, err := api.GetBranches(name)
+
+	if err != nil {
+		return cli.NewExitError(err.Error(), 1)
+	}
+
+	if len(branches) == 0 {
+		return cli.NewExitError("Cannot find branch", 1)
+	}
+
+	branch := branches[0]
+
+	err = api.DeleteBranch(branch.ID)
+
+	if err != nil {
+		return cli.NewExitError(err.Error(), 1)
+	}
+
+	fmt.Printf("Deleted branch %q.\n", name)
 	return nil
 }

--- a/branches.go
+++ b/branches.go
@@ -11,6 +11,7 @@ import (
 type branchAPI interface {
 	GetBranches(...string) ([]rainforest.Branch, error)
 	CreateBranch(*rainforest.Branch) error
+	MergeBranch(int) error
 	DeleteBranch(int) error
 }
 
@@ -33,6 +34,36 @@ func newBranch(c cliContext, api branchAPI) error {
 	}
 
 	fmt.Printf("Created branch %q.\n", name)
+	return nil
+}
+
+func mergeBranch(c cliContext, api branchAPI) error {
+	name := c.Args().First()
+	name = strings.TrimSpace(name)
+
+	if name == "" {
+		return cli.NewExitError("Branch name cannot be blank", 1)
+	}
+
+	branches, err := api.GetBranches(name)
+
+	if err != nil {
+		return cli.NewExitError(err.Error(), 1)
+	}
+
+	if len(branches) == 0 {
+		return cli.NewExitError("Cannot find branch", 1)
+	}
+
+	branch := branches[0]
+
+	err = api.MergeBranch(branch.ID)
+
+	if err != nil {
+		return cli.NewExitError(err.Error(), 1)
+	}
+
+	fmt.Printf("Merged branch %q into main.\n", name)
 	return nil
 }
 

--- a/branches.go
+++ b/branches.go
@@ -17,18 +17,17 @@ type branchAPI interface {
 }
 
 func newBranch(c cliContext, api branchAPI) error {
-	name := c.Args().First()
-	name = strings.TrimSpace(name)
+	name, err := getBranchName(c)
 
-	if name == "" {
-		return cli.NewExitError("Branch name cannot be blank", 1)
+	if err != nil {
+		return cli.NewExitError(err.Error(), 1)
 	}
 
 	branch := rainforest.Branch{
 		Name: name,
 	}
 
-	err := api.CreateBranch(&branch)
+	err = api.CreateBranch(&branch)
 
 	if err != nil {
 		return cli.NewExitError(err.Error(), 1)
@@ -39,11 +38,10 @@ func newBranch(c cliContext, api branchAPI) error {
 }
 
 func mergeBranch(c cliContext, api branchAPI) error {
-	name := c.Args().First()
-	name = strings.TrimSpace(name)
+	name, err := getBranchName(c)
 
-	if name == "" {
-		return cli.NewExitError("Branch name cannot be blank", 1)
+	if err != nil {
+		return cli.NewExitError(err.Error(), 1)
 	}
 
 	branchID, err := getBranchID(name, api)
@@ -63,11 +61,10 @@ func mergeBranch(c cliContext, api branchAPI) error {
 }
 
 func deleteBranch(c cliContext, api branchAPI) error {
-	name := c.Args().First()
-	name = strings.TrimSpace(name)
+	name, err := getBranchName(c)
 
-	if name == "" {
-		return cli.NewExitError("Branch name cannot be blank", 1)
+	if err != nil {
+		return cli.NewExitError(err.Error(), 1)
 	}
 
 	branchID, err := getBranchID(name, api)
@@ -101,4 +98,16 @@ func getBranchID(name string, api branchAPI) (int, error) {
 	branch := branches[0]
 
 	return branch.ID, nil
+}
+
+// getBranchName gets branchName from the cli
+func getBranchName(c cliContext) (string, error) {
+	name := c.Args().First()
+	name = strings.TrimSpace(name)
+
+	if name == "" {
+		return "", errors.New("Branch name cannot be blank")
+	}
+
+	return name, nil
 }

--- a/branches.go
+++ b/branches.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -45,19 +46,13 @@ func mergeBranch(c cliContext, api branchAPI) error {
 		return cli.NewExitError("Branch name cannot be blank", 1)
 	}
 
-	branches, err := api.GetBranches(name)
+	branchID, err := getBranchID(name, api)
 
 	if err != nil {
 		return cli.NewExitError(err.Error(), 1)
 	}
 
-	if len(branches) == 0 {
-		return cli.NewExitError("Cannot find branch", 1)
-	}
-
-	branch := branches[0]
-
-	err = api.MergeBranch(branch.ID)
+	err = api.MergeBranch(branchID)
 
 	if err != nil {
 		return cli.NewExitError(err.Error(), 1)
@@ -75,19 +70,13 @@ func deleteBranch(c cliContext, api branchAPI) error {
 		return cli.NewExitError("Branch name cannot be blank", 1)
 	}
 
-	branches, err := api.GetBranches(name)
+	branchID, err := getBranchID(name, api)
 
 	if err != nil {
 		return cli.NewExitError(err.Error(), 1)
 	}
 
-	if len(branches) == 0 {
-		return cli.NewExitError("Cannot find branch", 1)
-	}
-
-	branch := branches[0]
-
-	err = api.DeleteBranch(branch.ID)
+	err = api.DeleteBranch(branchID)
 
 	if err != nil {
 		return cli.NewExitError(err.Error(), 1)
@@ -95,4 +84,21 @@ func deleteBranch(c cliContext, api branchAPI) error {
 
 	fmt.Printf("Deleted branch %q.\n", name)
 	return nil
+}
+
+// getBranchID gets branchID by using the branch name to query the API
+func getBranchID(name string, api branchAPI) (int, error) {
+	branches, err := api.GetBranches(name)
+
+	if err != nil {
+		return 0, err
+	}
+
+	if len(branches) == 0 {
+		return 0, errors.New("Cannot find branch")
+	}
+
+	branch := branches[0]
+
+	return branch.ID, nil
 }

--- a/branches_test.go
+++ b/branches_test.go
@@ -7,22 +7,13 @@ import (
 )
 
 type testBranchAPI struct {
+	handleGetBranches func(params ...string) ([]rainforest.Branch, error)
 }
 
 func (t *testBranchAPI) GetBranches(params ...string) ([]rainforest.Branch, error) {
-	branches := []rainforest.Branch{}
-	name := params[0]
+	branches, err := t.handleGetBranches(params...)
 
-	if name != "non-existing-branch" {
-		branch := rainforest.Branch{
-			ID:   1,
-			Name: name,
-		}
-
-		branches = append(branches, branch)
-	}
-
-	return branches, nil
+	return branches, err
 }
 
 func (t *testBranchAPI) CreateBranch(branch *rainforest.Branch) error {
@@ -79,6 +70,22 @@ func TestDeleteBranch(t *testing.T) {
 	context := new(fakeContext)
 	testAPI := new(testBranchAPI)
 
+	testAPI.handleGetBranches = func(params ...string) ([]rainforest.Branch, error) {
+		branches := []rainforest.Branch{}
+		name := params[0]
+
+		if name != "non-existing-branch" {
+			branch := rainforest.Branch{
+				ID:   1,
+				Name: name,
+			}
+
+			branches = append(branches, branch)
+		}
+
+		return branches, nil
+	}
+
 	testCases := []struct {
 		branchName    string
 		errorExpected bool
@@ -117,6 +124,22 @@ func TestDeleteBranch(t *testing.T) {
 func TestMergeBranch(t *testing.T) {
 	context := new(fakeContext)
 	testAPI := new(testBranchAPI)
+
+	testAPI.handleGetBranches = func(params ...string) ([]rainforest.Branch, error) {
+		branches := []rainforest.Branch{}
+		name := params[0]
+
+		if name != "non-existing-branch" {
+			branch := rainforest.Branch{
+				ID:   1,
+				Name: name,
+			}
+
+			branches = append(branches, branch)
+		}
+
+		return branches, nil
+	}
 
 	testCases := []struct {
 		branchName    string

--- a/branches_test.go
+++ b/branches_test.go
@@ -9,7 +9,27 @@ import (
 type testBranchAPI struct {
 }
 
+func (t *testBranchAPI) GetBranches(params ...string) ([]rainforest.Branch, error) {
+	branches := []rainforest.Branch{}
+	name := params[0]
+
+	if name != "non-existing-branch" {
+		branch := rainforest.Branch{
+			ID:   1,
+			Name: name,
+		}
+
+		branches = append(branches, branch)
+	}
+
+	return branches, nil
+}
+
 func (t *testBranchAPI) CreateBranch(branch *rainforest.Branch) error {
+	return nil
+}
+
+func (t *testBranchAPI) DeleteBranch(branchID int) error {
 	return nil
 }
 
@@ -42,6 +62,45 @@ func TestNewBranch(t *testing.T) {
 			errorMessage := err.Error()
 			if errorMessage != expectedErrorMessage {
 				t.Errorf("newBranch returned error %+v, want %+v", errorMessage, expectedErrorMessage)
+			}
+		}
+
+		if err != nil && !errorExpected {
+			t.Fatal(err.Error())
+		}
+	}
+}
+
+func TestDeleteBranch(t *testing.T) {
+	context := new(fakeContext)
+	testAPI := new(testBranchAPI)
+
+	testCases := []struct {
+		branchName    string
+		errorExpected bool
+		errorMessage  string
+	}{
+		{"existing-branch", false, ""},
+		{"non-existing-branch", true, "Cannot find branch"},
+		{"", true, "Branch name cannot be blank"},
+		{" \n\t ", true, "Branch name cannot be blank"},
+	}
+
+	for _, testCase := range testCases {
+		context.args = []string{testCase.branchName}
+
+		err := deleteBranch(context, testAPI)
+		errorExpected := testCase.errorExpected
+		expectedErrorMessage := testCase.errorMessage
+
+		if errorExpected {
+			if err == nil {
+				t.Fatal("Expected error, but none occured.")
+			}
+
+			errorMessage := err.Error()
+			if errorMessage != expectedErrorMessage {
+				t.Errorf("deleteBranch returned error %+v, want %+v", errorMessage, expectedErrorMessage)
 			}
 		}
 

--- a/branches_test.go
+++ b/branches_test.go
@@ -29,6 +29,10 @@ func (t *testBranchAPI) CreateBranch(branch *rainforest.Branch) error {
 	return nil
 }
 
+func (t *testBranchAPI) MergeBranch(branchID int) error {
+	return nil
+}
+
 func (t *testBranchAPI) DeleteBranch(branchID int) error {
 	return nil
 }
@@ -101,6 +105,45 @@ func TestDeleteBranch(t *testing.T) {
 			errorMessage := err.Error()
 			if errorMessage != expectedErrorMessage {
 				t.Errorf("deleteBranch returned error %+v, want %+v", errorMessage, expectedErrorMessage)
+			}
+		}
+
+		if err != nil && !errorExpected {
+			t.Fatal(err.Error())
+		}
+	}
+}
+
+func TestMergeBranch(t *testing.T) {
+	context := new(fakeContext)
+	testAPI := new(testBranchAPI)
+
+	testCases := []struct {
+		branchName    string
+		errorExpected bool
+		errorMessage  string
+	}{
+		{"existing-branch", false, ""},
+		{"non-existing-branch", true, "Cannot find branch"},
+		{"", true, "Branch name cannot be blank"},
+		{" \n\t ", true, "Branch name cannot be blank"},
+	}
+
+	for _, testCase := range testCases {
+		context.args = []string{testCase.branchName}
+
+		err := mergeBranch(context, testAPI)
+		errorExpected := testCase.errorExpected
+		expectedErrorMessage := testCase.errorMessage
+
+		if errorExpected {
+			if err == nil {
+				t.Fatal("Expected error, but none occured.")
+			}
+
+			errorMessage := err.Error()
+			if errorMessage != expectedErrorMessage {
+				t.Errorf("mergeBranch returned error %+v, want %+v", errorMessage, expectedErrorMessage)
 			}
 		}
 

--- a/branches_test.go
+++ b/branches_test.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/rainforestapp/rainforest-cli/rainforest"
+)
+
+type testBranchAPI struct {
+}
+
+func (t *testBranchAPI) CreateBranch(branch *rainforest.Branch) error {
+	return nil
+}
+
+func TestNewBranch(t *testing.T) {
+	context := new(fakeContext)
+	testAPI := new(testBranchAPI)
+
+	testCases := []struct {
+		branchName    string
+		errorExpected bool
+		errorMessage  string
+	}{
+		{"new-branch", false, ""},
+		{"", true, "Branch name cannot be blank"},
+		{" \n\t ", true, "Branch name cannot be blank"},
+	}
+
+	for _, testCase := range testCases {
+		context.args = []string{testCase.branchName}
+
+		err := newBranch(context, testAPI)
+		errorExpected := testCase.errorExpected
+		expectedErrorMessage := testCase.errorMessage
+
+		if errorExpected {
+			if err == nil {
+				t.Fatal("Expected error, but none occured.")
+			}
+
+			errorMessage := err.Error()
+			if errorMessage != expectedErrorMessage {
+				t.Errorf("newBranch returned error %+v, want %+v", errorMessage, expectedErrorMessage)
+			}
+		}
+
+		if err != nil && !errorExpected {
+			t.Fatal(err.Error())
+		}
+	}
+}

--- a/rainforest-cli.go
+++ b/rainforest-cli.go
@@ -284,6 +284,10 @@ func main() {
 					Name:  "save-run-id",
 					Usage: "Save the created run's ID to `FILE`.",
 				},
+				cli.StringFlag{
+					Name:  "branch, branch-name",
+					Usage: "Starts the run on a specific branch.",
+				},
 			},
 		},
 		{

--- a/rainforest-cli.go
+++ b/rainforest-cli.go
@@ -608,6 +608,13 @@ func main() {
 					},
 				},
 				{
+					Name:  "merge",
+					Usage: "Merge an existing branch into main",
+					Action: func(c *cli.Context) error {
+						return mergeBranch(c, api)
+					},
+				},
+				{
 					Name:  "delete",
 					Usage: "Delete an existing branch",
 					Action: func(c *cli.Context) error {

--- a/rainforest-cli.go
+++ b/rainforest-cli.go
@@ -594,6 +594,21 @@ func main() {
 				return updateCmd(c)
 			},
 		},
+		{
+			Name:         "branch",
+			Usage:        "Manage branches",
+			ArgsUsage:    "[command] [branch name]",
+			OnUsageError: onCommandUsageErrorHandler("branch"),
+			Subcommands: []cli.Command{
+				{
+					Name:  "new",
+					Usage: "Create a new branch",
+					Action: func(c *cli.Context) error {
+						return newBranch(c, api)
+					},
+				},
+			},
+		},
 	}
 
 	app.Run(shuffleFlags(os.Args))

--- a/rainforest-cli.go
+++ b/rainforest-cli.go
@@ -607,6 +607,13 @@ func main() {
 						return newBranch(c, api)
 					},
 				},
+				{
+					Name:  "delete",
+					Usage: "Delete an existing branch",
+					Action: func(c *cli.Context) error {
+						return deleteBranch(c, api)
+					},
+				},
 			},
 		},
 	}

--- a/rainforest-cli.go
+++ b/rainforest-cli.go
@@ -385,6 +385,10 @@ func main() {
 					Usage:  "`PATH` where to look for a tests to upload.",
 					EnvVar: "RAINFOREST_TEST_FOLDER",
 				},
+				cli.StringFlag{
+					Name:  "branch, branch-name",
+					Usage: "Uploads tests on a specific branch.",
+				},
 				cli.BoolFlag{
 					Name:  "synchronous-upload",
 					Usage: "Uploads your test in a synchronous manner i.e. not using concurrency.",

--- a/rainforest/branches.go
+++ b/rainforest/branches.go
@@ -1,9 +1,63 @@
 package rainforest
 
+import (
+	"fmt"
+	"strconv"
+)
+
 // Branch is a struct representing a Rainforest Branch
 type Branch struct {
 	ID   int    `json:"id,omitempty"`
 	Name string `json:"name"`
+}
+
+// GetBranches returns all branches optionally filtered by name
+func (c *Client) GetBranches(params ...string) ([]Branch, error) {
+	name := ""
+	branches := []Branch{}
+	page := 1
+
+	if len(params) > 0 {
+		name = params[0]
+	}
+
+	for {
+		branchesURL := "branches?page_size=50&page=" + strconv.Itoa(page)
+
+		if name != "" {
+			branchesURL = branchesURL + "&name=" + name
+		}
+
+		req, err := c.NewRequest("GET", branchesURL, nil)
+
+		if err != nil {
+			return nil, err
+		}
+
+		var branchResp []Branch
+		_, err = c.Do(req, &branchResp)
+		if err != nil {
+			return nil, err
+		}
+
+		branches = append(branches, branchResp...)
+
+		totalPagesHeader := c.LastResponseHeaders.Get("X-Total-Pages")
+		if totalPagesHeader == "" {
+			return nil, fmt.Errorf("Rainforest API error: Total pages header missing from response")
+		}
+
+		totalPages, err := strconv.Atoi(totalPagesHeader)
+		if err != nil {
+			return nil, err
+		}
+
+		if page == totalPages {
+			return branches, nil
+		}
+
+		page++
+	}
 }
 
 // CreateBranch creates new branch on RF, requires Branch struct to be prepared to upload using helpers
@@ -21,5 +75,21 @@ func (c *Client) CreateBranch(branch *Branch) error {
 		return err
 	}
 
+	return nil
+}
+
+// DeleteBranch deletes an existing branch on RF specified by ID
+func (c *Client) DeleteBranch(branchID int) error {
+	// Prepare request
+	req, err := c.NewRequest("DELETE", "branches/"+strconv.Itoa(branchID), nil)
+	if err != nil {
+		return err
+	}
+
+	// Send request and process response
+	_, err = c.Do(req, nil)
+	if err != nil {
+		return err
+	}
 	return nil
 }

--- a/rainforest/branches.go
+++ b/rainforest/branches.go
@@ -78,6 +78,22 @@ func (c *Client) CreateBranch(branch *Branch) error {
 	return nil
 }
 
+// MergeBranch merges an existing branch into the client's main branch
+func (c *Client) MergeBranch(branchID int) error {
+	// Prepare request
+	req, err := c.NewRequest("PUT", "branches/"+strconv.Itoa(branchID)+"/merge", nil)
+	if err != nil {
+		return err
+	}
+
+	// Send request and process response
+	_, err = c.Do(req, nil)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 // DeleteBranch deletes an existing branch on RF specified by ID
 func (c *Client) DeleteBranch(branchID int) error {
 	// Prepare request

--- a/rainforest/branches.go
+++ b/rainforest/branches.go
@@ -1,0 +1,25 @@
+package rainforest
+
+// Branch is a struct representing a Rainforest Branch
+type Branch struct {
+	ID   int    `json:"id,omitempty"`
+	Name string `json:"name"`
+}
+
+// CreateBranch creates new branch on RF, requires Branch struct to be prepared to upload using helpers
+func (c *Client) CreateBranch(branch *Branch) error {
+	// Prepare request
+	req, err := c.NewRequest("POST", "branches", branch)
+
+	if err != nil {
+		return err
+	}
+
+	// Send request and process response
+	_, err = c.Do(req, nil)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/rainforest/branches.go
+++ b/rainforest/branches.go
@@ -5,6 +5,8 @@ import (
 	"strconv"
 )
 
+const NO_BRANCH = 0
+
 // Branch is a struct representing a Rainforest Branch
 type Branch struct {
 	ID   int    `json:"id,omitempty"`

--- a/rainforest/branches_test.go
+++ b/rainforest/branches_test.go
@@ -1,0 +1,44 @@
+package rainforest
+
+import (
+	"bytes"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestCreateBranch(t *testing.T) {
+	testCases := []struct {
+		branch       Branch
+		expectedBody string
+	}{
+		{
+			branch:       Branch{Name: "branch"},
+			expectedBody: `{"name":"branch"}`,
+		},
+	}
+
+	for _, testCase := range testCases {
+		setup()
+		defer cleanup()
+
+		const requestMethod = "POST"
+		mux.HandleFunc("/branches", func(w http.ResponseWriter, request *http.Request) {
+			if request.Method != requestMethod {
+				t.Errorf("Request method = %v, want %v", request.Method, requestMethod)
+			}
+
+			buffer := new(bytes.Buffer)
+			buffer.ReadFrom(request.Body)
+			response := strings.TrimSpace(buffer.String())
+			if response != testCase.expectedBody {
+				t.Errorf("Request body = %v, want %v", response, testCase.expectedBody)
+			}
+		})
+
+		err := client.CreateBranch(&testCase.branch)
+		if err != nil {
+			t.Fatal(err.Error())
+		}
+	}
+}

--- a/rainforest/runner.go
+++ b/rainforest/runner.go
@@ -21,6 +21,7 @@ type RunParams struct {
 	Release              string      `json:"release,omitempty"`
 	EnvironmentID        int         `json:"environment_id,omitempty"`
 	FeatureID            int         `json:"feature_id,omitempty"`
+	BranchID             int         `json:"branch_id,omitempty"`
 	RunGroupID           int         `json:"-"`
 	RunID                int         `json:"-"`
 	AutomationMaxRetries int         `json:"automation_max_retries,omitempty"`
@@ -114,6 +115,9 @@ func validateRerunParams(params RunParams) error {
 	}
 	if params.RunGroupID != 0 {
 		return errors.New("Run Group cannot be specified for rerun")
+	}
+	if params.BranchID != 0 {
+		return errors.New("Branch cannot be specified for rerun")
 	}
 
 	return nil

--- a/rainforest/runner_test.go
+++ b/rainforest/runner_test.go
@@ -149,6 +149,10 @@ func TestCreateRunFromRerun(t *testing.T) {
 			RunID:      runID,
 			RunGroupID: 123,
 		},
+		{
+			RunID:    runID,
+			BranchID: 123,
+		},
 	}
 	mux.HandleFunc(fmt.Sprintf("/runs/%v/rerun_failed", runID), func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprint(w, `{"id": 123, "state":"in_progress"}`)

--- a/rainforest/tests.go
+++ b/rainforest/tests.go
@@ -509,17 +509,19 @@ func (c *Client) CreateTest(test *RFTest) error {
 }
 
 // UpdateTest updates existing test on RF, requires RFTest struct to be prepared to upload using helpers
-func (c *Client) UpdateTest(test *RFTest) error {
+func (c *Client) UpdateTest(test *RFTest, branchID int) error {
 	if test.TestID == 0 {
 		return errors.New("Couldn't update the test TestID not specified in RFTest")
 	}
 
+	url := fmt.Sprintf("tests/%d?slim=true", test.TestID)
+
+	if branchID != 0 {
+		url += fmt.Sprintf("&branch_id=%d", branchID)
+	}
+
 	// Prepare request
-	req, err := c.NewRequest(
-		"PUT",
-		fmt.Sprintf("tests/%d?slim=true", test.TestID),
-		test,
-	)
+	req, err := c.NewRequest("PUT", url, test)
 	if err != nil {
 		return err
 	}

--- a/rainforest/tests.go
+++ b/rainforest/tests.go
@@ -516,7 +516,7 @@ func (c *Client) UpdateTest(test *RFTest, branchID int) error {
 
 	url := fmt.Sprintf("tests/%d?slim=true", test.TestID)
 
-	if branchID != 0 {
+	if branchID != NO_BRANCH {
 		url += fmt.Sprintf("&branch_id=%d", branchID)
 	}
 

--- a/rainforest/tests_test.go
+++ b/rainforest/tests_test.go
@@ -433,9 +433,14 @@ func TestUpdateTest(t *testing.T) {
 		} else if strings.Contains(bodyStr, "\"feature_id\"") {
 			t.Errorf("Unexpected parameter found: \"feature_id\" in:\n%v", bodyStr)
 		}
+
+		branchID := r.URL.Query().Get("branch_id")
+		if branchID != "" {
+			t.Error("Branch ID present in URL when it shouldn't be.")
+		}
 	})
 
-	err = client.UpdateTest(&rfTest)
+	err = client.UpdateTest(&rfTest, 0)
 	if err != nil {
 		t.Error(err.Error())
 	}
@@ -483,7 +488,29 @@ func TestUpdateTest(t *testing.T) {
 		}
 	})
 
-	err = client.UpdateTest(&rfTest)
+	err = client.UpdateTest(&rfTest, 0)
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	// With a branch id
+	cleanup()
+	setup()
+
+	mux.HandleFunc("/tests/", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "PUT" {
+			t.Errorf("Incorrect HTTP method - expected PUT, got %v", r.Method)
+			return
+		}
+
+		branchID := r.URL.Query().Get("branch_id")
+
+		if branchID != "123" {
+			t.Errorf("Unexpected Branch ID received. Expected: 123, Got: %v", branchID)
+		}
+	})
+
+	err = client.UpdateTest(&rfTest, 123)
 	if err != nil {
 		t.Error(err.Error())
 	}
@@ -520,7 +547,7 @@ func TestUpdateTest(t *testing.T) {
 		}
 	})
 
-	err = client.UpdateTest(&rfTest)
+	err = client.UpdateTest(&rfTest, 0)
 	if err != nil {
 		t.Error(err.Error())
 	}

--- a/rainforest/tests_test.go
+++ b/rainforest/tests_test.go
@@ -440,7 +440,7 @@ func TestUpdateTest(t *testing.T) {
 		}
 	})
 
-	err = client.UpdateTest(&rfTest, 0)
+	err = client.UpdateTest(&rfTest, NO_BRANCH)
 	if err != nil {
 		t.Error(err.Error())
 	}
@@ -488,7 +488,7 @@ func TestUpdateTest(t *testing.T) {
 		}
 	})
 
-	err = client.UpdateTest(&rfTest, 0)
+	err = client.UpdateTest(&rfTest, NO_BRANCH)
 	if err != nil {
 		t.Error(err.Error())
 	}
@@ -547,7 +547,7 @@ func TestUpdateTest(t *testing.T) {
 		}
 	})
 
-	err = client.UpdateTest(&rfTest, 0)
+	err = client.UpdateTest(&rfTest, NO_BRANCH)
 	if err != nil {
 		t.Error(err.Error())
 	}

--- a/runner.go
+++ b/runner.go
@@ -161,7 +161,7 @@ func (r *runner) prepareLocalRun(c cliContext) ([]*rainforest.RFTest, error) {
 	if err != nil {
 		return nil, err
 	}
-	err = uploadRFMLFiles(uploads, true, r.client)
+	err = uploadRFMLFiles(uploads, 0, true, r.client)
 	if err != nil {
 		return nil, err
 	}

--- a/runner.go
+++ b/runner.go
@@ -65,16 +65,30 @@ func (r *runner) startRun(c cliContext) error {
 		)
 	}
 
-	var localTests []*rainforest.RFTest
 	var err error
+	var branchID int
+	branchName := c.String("branch")
+	branchName = strings.TrimSpace(branchName)
+	if branchName != "" {
+		branchID, err = getBranchID(branchName, r.client)
+	} else {
+		branchID = 0
+		err = nil
+	}
+
+	if err != nil {
+		return cli.NewExitError(err.Error(), 1)
+	}
+
+	var localTests []*rainforest.RFTest
 	if c.Bool("f") {
-		localTests, err = r.prepareLocalRun(c)
+		localTests, err = r.prepareLocalRun(c, branchID)
 		if err != nil {
 			return cli.NewExitError(err.Error(), 1)
 		}
 	}
 
-	params, err := r.makeRunParams(c, localTests)
+	params, err := r.makeRunParams(c, localTests, branchID)
 	if err != nil {
 		return cli.NewExitError(err.Error(), 1)
 	}
@@ -143,7 +157,7 @@ func (r *runner) showRunCreated(runStatus *rainforest.RunStatus) {
 	log.Printf("Run %v has been created. The detailed results are available at %v", runStatus.ID, runStatus.FrontendURL)
 }
 
-func (r *runner) prepareLocalRun(c cliContext) ([]*rainforest.RFTest, error) {
+func (r *runner) prepareLocalRun(c cliContext, branchID int) ([]*rainforest.RFTest, error) {
 	invalidFilters := []string{"folder", "feature", "run-group", "site"}
 	for _, filter := range invalidFilters {
 		if c.Int(filter) != 0 || (c.String(filter) != "" && c.String(filter) != "0") {
@@ -161,7 +175,7 @@ func (r *runner) prepareLocalRun(c cliContext) ([]*rainforest.RFTest, error) {
 	if err != nil {
 		return nil, err
 	}
-	err = uploadRFMLFiles(uploads, 0, true, r.client)
+	err = uploadRFMLFiles(uploads, branchID, true, r.client)
 	if err != nil {
 		return nil, err
 	}
@@ -360,7 +374,7 @@ func getRunStatus(failFast bool, runID int, client runnerAPI) (*rainforest.RunSt
 
 // makeRunParams parses and validates command line arguments + options
 // and makes RunParams struct out of them
-func (r *runner) makeRunParams(c cliContext, localTests []*rainforest.RFTest) (rainforest.RunParams, error) {
+func (r *runner) makeRunParams(c cliContext, localTests []*rainforest.RFTest, branchID int) (rainforest.RunParams, error) {
 	var err error
 	localOnly := localTests != nil
 
@@ -463,6 +477,7 @@ func (r *runner) makeRunParams(c cliContext, localTests []*rainforest.RFTest) (r
 		Release:              release,
 		EnvironmentID:        environmentID,
 		FeatureID:            featureID,
+		BranchID:             branchID,
 		RunGroupID:           runGroupID,
 		AutomationMaxRetries: automationMaxRetries,
 	}, nil

--- a/runner.go
+++ b/runner.go
@@ -72,7 +72,7 @@ func (r *runner) startRun(c cliContext) error {
 	if branchName != "" {
 		branchID, err = getBranchID(branchName, r.client)
 	} else {
-		branchID = 0
+		branchID = rainforest.NO_BRANCH
 		err = nil
 	}
 

--- a/runner_test.go
+++ b/runner_test.go
@@ -111,7 +111,7 @@ func (r *fakeRunnerClient) CreateTest(t *rainforest.RFTest) error {
 	return nil
 }
 
-func (r *fakeRunnerClient) UpdateTest(t *rainforest.RFTest) error {
+func (r *fakeRunnerClient) UpdateTest(t *rainforest.RFTest, branchID int) error {
 	// meh
 	return nil
 }

--- a/runner_test.go
+++ b/runner_test.go
@@ -265,7 +265,7 @@ func TestMakeRunParams(t *testing.T) {
 		r := newRunner()
 		fakeEnv := rainforest.Environment{ID: fakeEnvID, Name: "the foo environment"}
 		r.client = &fakeRunnerClient{environment: fakeEnv}
-		res, err := r.makeRunParams(c, nil)
+		res, err := r.makeRunParams(c, nil, 0)
 
 		if err != nil {
 			t.Errorf("Error trying to create params: %v", err)
@@ -343,8 +343,9 @@ func TestStartLocalRun(t *testing.T) {
 	}{
 		{
 			mappings: map[string]interface{}{
-				"f":   true,
-				"tag": []string{"foo", "bar"},
+				"f":      true,
+				"tag":    []string{"foo", "bar"},
+				"branch": "ranch",
 				// There's less to stub with bg
 				"bg": true,
 			},

--- a/runner_test.go
+++ b/runner_test.go
@@ -415,6 +415,22 @@ func TestStartLocalRun(t *testing.T) {
 		r := newRunner()
 		fakeEnv := rainforest.Environment{ID: 123, Name: "the foo environment"}
 		client := &fakeRunnerClient{environment: fakeEnv}
+		client.handleGetBranches = func(params ...string) ([]rainforest.Branch, error) {
+			branches := []rainforest.Branch{}
+			name := params[0]
+
+			if name != "non-existing-branch" {
+				branch := rainforest.Branch{
+					ID:   1,
+					Name: name,
+				}
+
+				branches = append(branches, branch)
+			}
+
+			return branches, nil
+		}
+
 		r.client = client
 
 		err := r.startRun(c)

--- a/tests_test.go
+++ b/tests_test.go
@@ -399,8 +399,24 @@ func TestUploadTests(t *testing.T) {
 	}
 
 	// with a branch
+	testAPI.handleGetBranches = func(params ...string) ([]rainforest.Branch, error) {
+		branches := []rainforest.Branch{}
+		name := params[0]
+
+		if name != "non-existing-branch" {
+			branch := rainforest.Branch{
+				ID:   123,
+				Name: name,
+			}
+
+			branches = append(branches, branch)
+		}
+
+		return branches, nil
+	}
+
 	testAPI.handleUpdateTest = func(rfTest *rainforest.RFTest, branchID int) {
-		if branchID != 1 {
+		if branchID != 123 {
 			t.Errorf("Incorrect value for branchID. Expected 123, Got %v", branchID)
 		}
 	}

--- a/tests_test.go
+++ b/tests_test.go
@@ -234,7 +234,8 @@ func TestNewRFMLTest(t *testing.T) {
 type testRfAPI struct {
 	testIDs          []rainforest.TestIDPair
 	tests            []rainforest.RFTest
-	handleUpdateTest func(*rainforest.RFTest)
+	handleUpdateTest func(*rainforest.RFTest, int)
+	testBranchAPI
 }
 
 func (t *testRfAPI) GetTestIDs() ([]rainforest.TestIDPair, error) {
@@ -263,8 +264,8 @@ func (t *testRfAPI) CreateTest(_ *rainforest.RFTest) error {
 	return errStub
 }
 
-func (t *testRfAPI) UpdateTest(test *rainforest.RFTest) error {
-	t.handleUpdateTest(test)
+func (t *testRfAPI) UpdateTest(test *rainforest.RFTest, branchID int) error {
+	t.handleUpdateTest(test, branchID)
 	return nil
 }
 
@@ -338,7 +339,7 @@ func TestUploadTests(t *testing.T) {
 	testAPI.testIDs = []rainforest.TestIDPair{{ID: testID, RFMLID: rfmlID}}
 
 	// basic test
-	testAPI.handleUpdateTest = func(rfTest *rainforest.RFTest) {
+	testAPI.handleUpdateTest = func(rfTest *rainforest.RFTest, branchID int) {
 		testCases := []struct {
 			fieldName string
 			expected  interface{}
@@ -376,7 +377,7 @@ func TestUploadTests(t *testing.T) {
 	}
 
 	// state is specified
-	testAPI.handleUpdateTest = func(rfTest *rainforest.RFTest) {
+	testAPI.handleUpdateTest = func(rfTest *rainforest.RFTest, branchID int) {
 		if rfTest.State != "disabled" {
 			t.Errorf("Incorrect value for state. Expected \"disabled\", Got %v", rfTest.State)
 		}
@@ -390,6 +391,23 @@ func TestUploadTests(t *testing.T) {
 	err = ioutil.WriteFile(testPath, []byte(testContents), os.ModePerm)
 	if err != nil {
 		t.Fatal(err.Error())
+	}
+
+	err = uploadTests(context, testAPI)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	// with a branch
+	testAPI.handleUpdateTest = func(rfTest *rainforest.RFTest, branchID int) {
+		if branchID != 1 {
+			t.Errorf("Incorrect value for branchID. Expected 123, Got %v", branchID)
+		}
+	}
+
+	context.mappings = map[string]interface{}{
+		"test-folder": testDefaultSpecFolder,
+		"branch":      "existing-branch",
 	}
 
 	err = uploadTests(context, testAPI)


### PR DESCRIPTION
This PR adds the following commands to the cli:
- `branch new <name>` creates a new branch
- `branch delete <name>` deletes an existing branch
- `branch merge <name>` merges an existing branch

It also adds the `--branch <name>` option to the `run` and `upload` commands enabling them to be applied to a branch.

I've added one command per commit and a separate refactoring commit, so reviewing per commit might be easier.