### PR TITLE
Use run description for temporary env name if one is present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Rainforest CLI Changelog
+## 3.4.0 - 2022-11-04
+- Use run description for temporary environment name if it is set
+  - (9e6caf7a0ee5221d53997e2d93a44d6635a81361, @magni-)
+
 ## 3.3.0 - 2022-10-24
 - Add commands for creating/merging/deleting branches
   - (676bb8478340ada9da35091762d5a3c0f767dd3c, @pyromaniackeca)

--- a/rainforest-cli.go
+++ b/rainforest-cli.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	// Version of the app in SemVer
-	version = "3.3.0"
+	version = "3.4.0"
 	// This is the default spec folder for RFML tests
 	defaultSpecFolder = "./spec/rainforest"
 )

--- a/rainforest/environments.go
+++ b/rainforest/environments.go
@@ -1,5 +1,7 @@
 package rainforest
 
+import "fmt"
+
 // EnvironmentParams are the parameters used to create a new Environment
 type EnvironmentParams struct {
 	Name        string `json:"name"`
@@ -16,9 +18,17 @@ type Environment struct {
 
 // CreateTemporaryEnvironment creates a new temporary environment and returns the
 // Environment.
-func (c *Client) CreateTemporaryEnvironment(urlString string) (*Environment, error) {
+func (c *Client) CreateTemporaryEnvironment(runDescription string, urlString string) (*Environment, error) {
+	name := "temporary-env-for-custom-url-via-CLI"
+	if runDescription != "" {
+		if len(runDescription) > 241 {
+			runDescription = runDescription[:241]
+		}
+		name = fmt.Sprintf("%v-temporary-env", runDescription)
+	}
+
 	body := EnvironmentParams{
-		Name:        "temporary-env-for-custom-url-via-CLI",
+		Name:        name,
 		URL:         urlString,
 		IsTemporary: true,
 	}

--- a/rainforest/environments_test.go
+++ b/rainforest/environments_test.go
@@ -9,40 +9,82 @@ import (
 )
 
 func TestCreateTemporaryEnvironment(t *testing.T) {
-	setup()
-	defer cleanup()
+	testCases := []struct {
+		runDescription string
+		urlString      string
+		envID          int
+		expected       EnvironmentParams
+	}{
+		{
+			runDescription: "",
+			urlString:      "https://no-name.url",
+			envID:          7331,
+			expected: EnvironmentParams{
+				Name:        "temporary-env-for-custom-url-via-CLI",
+				URL:         "https://no-name.url",
+				IsTemporary: true,
+			},
+		},
+		{
+			runDescription: "my-run-description",
+			urlString:      "https://with-a-name.url",
+			envID:          7332,
+			expected: EnvironmentParams{
+				Name:        "my-run-description-temporary-env",
+				URL:         "https://with-a-name.url",
+				IsTemporary: true,
+			},
+		},
+		{
+			runDescription: "My run with a giant description that goes on for over 255 characters, count them if you must. No seriously this is more than that. This won't fit in the environments table's name column, so we'll have to trim some off if we don't want this to loudly blow up.",
+			urlString:      "https://with-a-name.url",
+			envID:          7332,
+			expected: EnvironmentParams{
+				Name:        "My run with a giant description that goes on for over 255 characters, count them if you must. No seriously this is more than that. This won't fit in the environments table's name column, so we'll have to trim some off if we don't want this t-temporary-env",
+				URL:         "https://with-a-name.url",
+				IsTemporary: true,
+			},
+		},
+	}
 
-	expectedID := 7331
+	for _, testCase := range testCases {
+		setup()
+		defer cleanup()
 
-	mux.HandleFunc("/environments", func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == "POST" {
-			body, err := ioutil.ReadAll(r.Body)
-			if err != nil {
-				t.Errorf("Error parsing request body: %v", err.Error())
+		mux.HandleFunc("/environments", func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == "POST" {
+				body, err := ioutil.ReadAll(r.Body)
+				if err != nil {
+					t.Errorf("Error parsing request body: %v", err.Error())
+				}
+				p := EnvironmentParams{}
+				err = json.Unmarshal(body, &p)
+				if err != nil {
+					t.Errorf("Error unmarshalling request body: %v", err.Error())
+				}
+
+				if p != testCase.expected {
+					t.Errorf("Unexpected request body. Want %v, Got %v", testCase.expected, p)
+				}
+
+				resJSON := fmt.Sprintf(`{"id":%v,"name":"%v","temporary":true}`, testCase.envID, p.Name)
+				w.Write([]byte(resJSON))
+			} else {
+				t.Errorf("Unexpected request method: %v", r.Method)
 			}
-			p := EnvironmentParams{}
-			err = json.Unmarshal(body, &p)
-			if err != nil {
-				t.Errorf("Error unmarshalling request body: %v", err.Error())
-			}
+		})
 
-			resJSON := fmt.Sprintf(`{"id":%v,"name":"%v","temporary":true}`, expectedID, p.Name)
-			w.Write([]byte(resJSON))
-		} else {
-			t.Errorf("Unexpected request method: %v", r.Method)
+		env, err := client.CreateTemporaryEnvironment(testCase.runDescription, testCase.urlString)
+		if err != nil {
+			t.Error(err.Error())
 		}
-	})
 
-	env, err := client.CreateTemporaryEnvironment("https://www.rainforestqa.com/")
-	if err != nil {
-		t.Error(err.Error())
-	}
+		if env.ID != testCase.envID {
+			t.Errorf("Correct ID not found in environment. Want %v, Got %v", testCase.envID, env.ID)
+		}
 
-	if env.ID != expectedID {
-		t.Errorf("Correct ID not found in environment. Want %v, Got %v", expectedID, env.ID)
-	}
-
-	if env.Name == "" {
-		t.Error("Name not properly assigned to environment struct. Got empty string.")
+		if env.Name != testCase.expected.Name {
+			t.Errorf("Name not properly assigned to environment struct. Want %v, Got %v", testCase.expected.Name, env.Name)
+		}
 	}
 }

--- a/runner.go
+++ b/runner.go
@@ -19,7 +19,7 @@ import (
 
 type runnerAPI interface {
 	CreateRun(params rainforest.RunParams) (*rainforest.RunStatus, error)
-	CreateTemporaryEnvironment(string) (*rainforest.Environment, error)
+	CreateTemporaryEnvironment(string, string) (*rainforest.Environment, error)
 	CheckRunStatus(int) (*rainforest.RunStatus, error)
 	rfAPI
 }
@@ -425,7 +425,7 @@ func (r *runner) makeRunParams(c cliContext, localTests []*rainforest.RFTest, br
 		}
 
 		var environment *rainforest.Environment
-		environment, err = r.client.CreateTemporaryEnvironment(customURL.String())
+		environment, err = r.client.CreateTemporaryEnvironment(description, customURL.String())
 		if err != nil {
 			return rainforest.RunParams{}, err
 		}

--- a/runner_test.go
+++ b/runner_test.go
@@ -116,7 +116,7 @@ func (r *fakeRunnerClient) UpdateTest(t *rainforest.RFTest, branchID int) error 
 	return nil
 }
 
-func (r *fakeRunnerClient) CreateTemporaryEnvironment(s string) (*rainforest.Environment, error) {
+func (r *fakeRunnerClient) CreateTemporaryEnvironment(n string, s string) (*rainforest.Environment, error) {
 	return &r.environment, nil
 }
 


### PR DESCRIPTION
Otherwise default to the existing behavior.

This will help clients with tons of concurrent temporary environments to distinguish between them:

![image](https://user-images.githubusercontent.com/1640976/199859686-4c641171-1a36-42c7-a742-c7bd9ea0f50b.png)
