### PR TITLE
[RF-26747] Handle paginated responses from backend when fetching sites and environments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Rainforest CLI Changelog
+## 3.4.1 - 2021-01-23
+- Handle paginated responses from backend when fetching sites and environments
+  - (9f9a438d99d1ac646da1034707b88a33f5be64c2, @magni-)
+
 ## 3.4.0 - 2022-11-04
 - Use run description for temporary environment name if it is set
   - (9e6caf7a0ee5221d53997e2d93a44d6635a81361, @magni-)

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ For users of CircleCI and GitHub Actions, we have platform-specific wrappers you
 ```bash
 $ docker pull gcr.io/rf-public-images/rainforest-cli
 $ docker run gcr.io/rf-public-images/rainforest-cli --version
-Rainforest CLI version 2.19.0 - build: docker
+Rainforest CLI version 3.4.1 - build: docker
 ```
 
 ### Brew

--- a/rainforest-cli.go
+++ b/rainforest-cli.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	// Version of the app in SemVer
-	version = "3.4.0"
+	version = "3.4.1"
 	// This is the default spec folder for RFML tests
 	defaultSpecFolder = "./spec/rainforest"
 )

--- a/rainforest/resources.go
+++ b/rainforest/resources.go
@@ -190,36 +190,32 @@ type Site struct {
 
 // GetSites fetches sites available to use during the RF runs.
 func (c *Client) GetSites() ([]Site, error) {
-	// Prepare request
-	req, err := c.NewRequest("GET", "sites", nil)
-	if err != nil {
-		return nil, err
+	var sites []Site
+
+	collect := func(coll interface{}) {
+		newSites := coll.(*[]Site)
+		for _, site := range *newSites {
+			sites = append(sites, site)
+		}
 	}
 
-	// Send request and process response
-	var sitesResp []Site
-	_, err = c.Do(req, &sitesResp)
-	if err != nil {
-		return nil, err
-	}
-	return sitesResp, nil
+	err := c.getPaginatedResource("sites", &[]Site{}, collect)
+	return sites, err
 }
 
 // GetEnvironments fetches environments available to use during the RF runs.
 func (c *Client) GetEnvironments() ([]Environment, error) {
-	// Prepare request
-	req, err := c.NewRequest("GET", "environments", nil)
-	if err != nil {
-		return nil, err
+	var environments []Environment
+
+	collect := func(coll interface{}) {
+		newEnvironments := coll.(*[]Environment)
+		for _, environment := range *newEnvironments {
+			environments = append(environments, environment)
+		}
 	}
 
-	// Send request and process response
-	var envsResp []Environment
-	_, err = c.Do(req, &envsResp)
-	if err != nil {
-		return nil, err
-	}
-	return envsResp, nil
+	err := c.getPaginatedResource("environments", &[]Environment{}, collect)
+	return environments, err
 }
 
 // Feature represents a single feature returned by the API.

--- a/rainforest/resources.go
+++ b/rainforest/resources.go
@@ -36,7 +36,7 @@ func (c *Client) getPaginatedResource(endpoint string, coll interface{}, collect
 
 	totalPagesHeader := res.Header.Get("X-Total-Pages")
 	if totalPagesHeader == "" {
-		return fmt.Errorf("Missing X-Total-Pages header in HTTP Response")
+		totalPagesHeader = "1"
 	}
 
 	totalPages, err := strconv.Atoi(totalPagesHeader)


### PR DESCRIPTION
Pagination code is copy-pasted from what we already do when fetching features and folders.