### PR TITLE
[RF-26790] Update getBranchID to handle receiving multiple branches from the backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Rainforest CLI Changelog
+## Unreleased
+- Handle multiple matching branches when merging or deleting a branch
+  - (8c16acc9dcffdbf7a3cff509bcef143e7d915cc3, @magni-)
+
 ## 3.4.1 - 2021-01-23
 - Handle paginated responses from backend when fetching sites and environments
   - (9f9a438d99d1ac646da1034707b88a33f5be64c2, @magni-)

--- a/branches.go
+++ b/branches.go
@@ -91,13 +91,13 @@ func getBranchID(name string, api branchAPI) (int, error) {
 		return 0, err
 	}
 
-	if len(branches) == 0 {
-		return 0, errors.New("Cannot find branch")
+	for _, branch := range branches {
+		if branch.Name == name {
+			return branch.ID, nil
+		}
 	}
 
-	branch := branches[0]
-
-	return branch.ID, nil
+	return 0, errors.New("Cannot find branch")
 }
 
 // getBranchName gets branchName from the cli

--- a/rainforest/resources.go
+++ b/rainforest/resources.go
@@ -21,8 +21,10 @@ type Folder struct {
 // empty slice of the appropriate type, and collect is called every time
 // resources are added to the collection. The caller should handle collecting
 // the collection.
-func (c *Client) getPaginatedResource(endpoint string, coll interface{}, collect func(interface{})) error {
-	req, err := c.NewRequest("GET", endpoint+"?page_size=100", nil)
+func (c *Client) getPaginatedResource(endpoint string, coll interface{}, collect func(interface{}), params ...string) error {
+	params = append(params, "page_size=100")
+	query := strings.Join(params, "&")
+	req, err := c.NewRequest("GET", endpoint+"?"+query, nil)
 	if err != nil {
 		return err
 	}
@@ -46,7 +48,9 @@ func (c *Client) getPaginatedResource(endpoint string, coll interface{}, collect
 
 	for i := 1; i < totalPages; i++ {
 		page := strconv.Itoa(i + 1)
-		req, err = c.NewRequest("GET", endpoint+"?page_size=100&page="+page, nil)
+		pageParams := append(params, "page="+page)
+		query = strings.Join(pageParams, "&")
+		req, err = c.NewRequest("GET", endpoint+"?"+query, nil)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
`GET /branches?name=<name>`'s behavior is changing to be a (case-insensitive, partial match) filter rather than a (exact-match) lookup. This PR updates `getBranchID` to handle that change by returning the branch with the expected name rather than blindly returning the first branch.