### PR TITLE
[RF-26805] Handle paginated response from `GET /generators`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
 # Rainforest CLI Changelog
-## Unreleased
+## 3.4.2 - 2023-01-26
+- Narrow down query when fetching fetching generators (tabular variables)
+  - (4df4734009a8c7a461bb8e0f6ee92082d91a4451, @magni-)
+- Handle paginated responses from backend when fetching generators (tabular variables)
+  - (668e5245cd8884e5e1322499d0843c5388ba87d9, @magni-)
 - Handle multiple matching branches when merging or deleting a branch
   - (8c16acc9dcffdbf7a3cff509bcef143e7d915cc3, @magni-)
 
-## 3.4.1 - 2021-01-23
+## 3.4.1 - 2023-01-23
 - Handle paginated responses from backend when fetching sites and environments
   - (9f9a438d99d1ac646da1034707b88a33f5be64c2, @magni-)
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ For users of CircleCI and GitHub Actions, we have platform-specific wrappers you
 ```bash
 $ docker pull gcr.io/rf-public-images/rainforest-cli
 $ docker run gcr.io/rf-public-images/rainforest-cli --version
-Rainforest CLI version 3.4.1 - build: docker
+Rainforest CLI version 3.4.2 - build: docker
 ```
 
 ### Brew

--- a/rainforest-cli.go
+++ b/rainforest-cli.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	// Version of the app in SemVer
-	version = "3.4.1"
+	version = "3.4.2"
 	// This is the default spec folder for RFML tests
 	defaultSpecFolder = "./spec/rainforest"
 )

--- a/rainforest/tabularvars.go
+++ b/rainforest/tabularvars.go
@@ -33,7 +33,7 @@ type GeneratorRelatedTests struct {
 }
 
 // GetGenerators fetches a list of all available generators for the account
-func (c *Client) GetGenerators() ([]Generator, error) {
+func (c *Client) GetGenerators(params ...string) ([]Generator, error) {
 	var generators []Generator
 
 	collect := func(coll interface{}) {
@@ -43,7 +43,7 @@ func (c *Client) GetGenerators() ([]Generator, error) {
 		}
 	}
 
-	err := c.getPaginatedResource("generators", &[]Generator{}, collect)
+	err := c.getPaginatedResource("generators", &[]Generator{}, collect, params...)
 	return generators, err
 }
 

--- a/rainforest/tabularvars.go
+++ b/rainforest/tabularvars.go
@@ -34,19 +34,17 @@ type GeneratorRelatedTests struct {
 
 // GetGenerators fetches a list of all available generators for the account
 func (c *Client) GetGenerators() ([]Generator, error) {
-	// Prepare request
-	req, err := c.NewRequest("GET", "generators", nil)
-	if err != nil {
-		return nil, err
+	var generators []Generator
+
+	collect := func(coll interface{}) {
+		newGenerators := coll.(*[]Generator)
+		for _, generator := range *newGenerators {
+			generators = append(generators, generator)
+		}
 	}
 
-	// Send request and process response
-	var generatorResp []Generator
-	_, err = c.Do(req, &generatorResp)
-	if err != nil {
-		return nil, err
-	}
-	return generatorResp, nil
+	err := c.getPaginatedResource("generators", &[]Generator{}, collect)
+	return generators, err
 }
 
 // DeleteGenerator deletes generator with specified ID

--- a/rainforest/tabularvars.go
+++ b/rainforest/tabularvars.go
@@ -74,12 +74,13 @@ func (c *Client) CreateTabularVar(name, description string,
 	columns []string, singleUse bool) (*Generator, error) {
 	//Prepare request
 	type genCreateRequest struct {
-		Name        string   `json:"name,omitempty"`
-		Description string   `json:"description,omitempty"`
-		SingleUse   bool     `json:"single_use,omitempty"`
-		Columns     []string `json:"columns,omitempty"`
+		Name          string   `json:"name,omitempty"`
+		Description   string   `json:"description,omitempty"`
+		GeneratorType string   `json:"generator_type,omitempty"`
+		SingleUse     bool     `json:"single_use,omitempty"`
+		Columns       []string `json:"columns,omitempty"`
 	}
-	body := genCreateRequest{name, description, singleUse, columns}
+	body := genCreateRequest{name, description, "tabular", singleUse, columns}
 	req, err := c.NewRequest("POST", "generators", body)
 	if err != nil {
 		return &Generator{}, err

--- a/rainforest/tabularvars_test.go
+++ b/rainforest/tabularvars_test.go
@@ -94,7 +94,7 @@ func TestCreateTabularVar(t *testing.T) {
 		buf := new(bytes.Buffer)
 		buf.ReadFrom(r.Body)
 		s := strings.TrimSpace(buf.String())
-		if wantedBody := `{"name":"foo","description":"bar","columns":["baz","wut"]}`; s != wantedBody {
+		if wantedBody := `{"name":"foo","description":"bar","generator_type":"tabular","columns":["baz","wut"]}`; s != wantedBody {
 			t.Errorf("Request body = %v, want %v", s, wantedBody)
 		}
 		fmt.Fprint(w, `{"id":1337,"created_at":"2016-11-24T14:56:19Z","name":"foo","description":`+

--- a/tabularvars.go
+++ b/tabularvars.go
@@ -18,7 +18,7 @@ import (
 
 // tabularVariablesAPI is part of the API connected to the tabular variables
 type tabularVariablesAPI interface {
-	GetGenerators() ([]rainforest.Generator, error)
+	GetGenerators(params ...string) ([]rainforest.Generator, error)
 	DeleteGenerator(genID int) error
 	CreateTabularVar(name, description string,
 		columns []string, singleUse bool) (*rainforest.Generator, error)
@@ -44,7 +44,7 @@ func uploadTabularVar(api tabularVariablesAPI, pathToCSV, name string, overwrite
 	// Check if the variable exists in RF
 	var existingGenID int
 	var description string
-	generators, err := api.GetGenerators()
+	generators, err := api.GetGenerators("generator_type=tabular", "name="+name)
 	if err != nil {
 		return err
 	}

--- a/tabularvars_test.go
+++ b/tabularvars_test.go
@@ -53,7 +53,7 @@ func TestMin(t *testing.T) {
 }
 
 type fakeAPI struct {
-	getGenerators    func() ([]rainforest.Generator, error)
+	getGenerators    func(params ...string) ([]rainforest.Generator, error)
 	deleteGenerator  func(genID int) error
 	createTabularVar func(name, description string,
 		columns []string, singleUse bool) (*rainforest.Generator, error)
@@ -61,9 +61,9 @@ type fakeAPI struct {
 		targetColumns []string, rowData [][]string) error
 }
 
-func (f fakeAPI) GetGenerators() ([]rainforest.Generator, error) {
+func (f fakeAPI) GetGenerators(params ...string) ([]rainforest.Generator, error) {
 	if f.getGenerators != nil {
-		return f.getGenerators()
+		return f.getGenerators(params...)
 	}
 	return nil, nil
 }
@@ -240,7 +240,11 @@ func TestUploadTabularVar(t *testing.T) {
 			callCount["addGeneratorRowsFromTable"] = callCount["addGeneratorRowsFromTable"] + 1
 			return nil
 		},
-		getGenerators: func() ([]rainforest.Generator, error) {
+		getGenerators: func(params ...string) ([]rainforest.Generator, error) {
+			expectedParams := []string{"generator_type=tabular", "name=" + variableName}
+			if !reflect.DeepEqual(params, expectedParams) {
+				t.Errorf("Incorrect parameters passed to GetGenerators. Got %v, expected: %v", expectedParams, params)
+			}
 			callCount["getGenerators"] = callCount["getGenerators"] + 1
 			return []rainforest.Generator{
 				{
@@ -349,7 +353,12 @@ func TestUploadTabularVar_Exists_NoOverwrite(t *testing.T) {
 			callCount["addGeneratorRowsFromTable"] = callCount["addGeneratorRowsFromTable"] + 1
 			return nil
 		},
-		getGenerators: func() ([]rainforest.Generator, error) {
+		getGenerators: func(params ...string) ([]rainforest.Generator, error) {
+			expectedParams := []string{"generator_type=tabular", "name=" + variableName}
+			if !reflect.DeepEqual(params, expectedParams) {
+				t.Errorf("Incorrect parameters passed to GetGenerators. Got %v, expected: %v", expectedParams, params)
+			}
+
 			callCount["getGenerators"] = callCount["getGenerators"] + 1
 			return []rainforest.Generator{
 				{
@@ -451,7 +460,11 @@ func TestUploadTabularVar_Exists_Overwrite(t *testing.T) {
 			callCount["addGeneratorRowsFromTable"] = callCount["addGeneratorRowsFromTable"] + 1
 			return nil
 		},
-		getGenerators: func() ([]rainforest.Generator, error) {
+		getGenerators: func(params ...string) ([]rainforest.Generator, error) {
+			expectedParams := []string{"generator_type=tabular", "name=" + variableName}
+			if !reflect.DeepEqual(params, expectedParams) {
+				t.Errorf("Incorrect parameters passed to GetGenerators. Got %v, expected: %v", expectedParams, params)
+			}
 			callCount["getGenerators"] = callCount["getGenerators"] + 1
 			return []rainforest.Generator{
 				{
@@ -567,7 +580,11 @@ func TestCSVUpload(t *testing.T) {
 			callCount["addGeneratorRowsFromTable"] = callCount["addGeneratorRowsFromTable"] + 1
 			return nil
 		},
-		getGenerators: func() ([]rainforest.Generator, error) {
+		getGenerators: func(params ...string) ([]rainforest.Generator, error) {
+			expectedParams := []string{"generator_type=tabular", "name=" + variableName}
+			if !reflect.DeepEqual(params, expectedParams) {
+				t.Errorf("Incorrect parameters passed to GetGenerators. Got %v, expected: %v", expectedParams, params)
+			}
 			callCount["getGenerators"] = callCount["getGenerators"] + 1
 			return []rainforest.Generator{
 				{
@@ -687,7 +704,11 @@ func TestCSVUpload_MissingName(t *testing.T) {
 			callCount["addGeneratorRowsFromTable"] = callCount["addGeneratorRowsFromTable"] + 1
 			return nil
 		},
-		getGenerators: func() ([]rainforest.Generator, error) {
+		getGenerators: func(params ...string) ([]rainforest.Generator, error) {
+			expectedParams := []string{"generator_type=tabular", "name=" + variableName}
+			if !reflect.DeepEqual(params, expectedParams) {
+				t.Errorf("Incorrect parameters passed to GetGenerators. Got %v, expected: %v", expectedParams, params)
+			}
 			callCount["getGenerators"] = callCount["getGenerators"] + 1
 			return []rainforest.Generator{
 				{
@@ -799,7 +820,11 @@ func TestPreRunCSVUpload(t *testing.T) {
 			callCount["addGeneratorRowsFromTable"] = callCount["addGeneratorRowsFromTable"] + 1
 			return nil
 		},
-		getGenerators: func() ([]rainforest.Generator, error) {
+		getGenerators: func(params ...string) ([]rainforest.Generator, error) {
+			expectedParams := []string{"generator_type=tabular", "name=" + variableName}
+			if !reflect.DeepEqual(params, expectedParams) {
+				t.Errorf("Incorrect parameters passed to GetGenerators. Got %v, expected: %v", expectedParams, params)
+			}
 			callCount["getGenerators"] = callCount["getGenerators"] + 1
 			return []rainforest.Generator{
 				{
@@ -920,7 +945,11 @@ func TestPreRunCSVUpload_MissingName(t *testing.T) {
 			callCount["addGeneratorRowsFromTable"] = callCount["addGeneratorRowsFromTable"] + 1
 			return nil
 		},
-		getGenerators: func() ([]rainforest.Generator, error) {
+		getGenerators: func(params ...string) ([]rainforest.Generator, error) {
+			expectedParams := []string{"generator_type=tabular", "name=" + variableName}
+			if !reflect.DeepEqual(params, expectedParams) {
+				t.Errorf("Incorrect parameters passed to GetGenerators. Got %v, expected: %v", expectedParams, params)
+			}
 			callCount["getGenerators"] = callCount["getGenerators"] + 1
 			return []rainforest.Generator{
 				{

--- a/tabularvars_test.go
+++ b/tabularvars_test.go
@@ -52,7 +52,7 @@ func TestMin(t *testing.T) {
 	}
 }
 
-type fakePI struct {
+type fakeAPI struct {
 	getGenerators    func() ([]rainforest.Generator, error)
 	deleteGenerator  func(genID int) error
 	createTabularVar func(name, description string,
@@ -61,21 +61,21 @@ type fakePI struct {
 		targetColumns []string, rowData [][]string) error
 }
 
-func (f fakePI) GetGenerators() ([]rainforest.Generator, error) {
+func (f fakeAPI) GetGenerators() ([]rainforest.Generator, error) {
 	if f.getGenerators != nil {
 		return f.getGenerators()
 	}
 	return nil, nil
 }
 
-func (f fakePI) DeleteGenerator(genID int) error {
+func (f fakeAPI) DeleteGenerator(genID int) error {
 	if f.deleteGenerator != nil {
 		return f.deleteGenerator(genID)
 	}
 	return nil
 }
 
-func (f fakePI) CreateTabularVar(name, description string,
+func (f fakeAPI) CreateTabularVar(name, description string,
 	columns []string, singleUse bool) (*rainforest.Generator, error) {
 	if f.createTabularVar != nil {
 		return f.createTabularVar(name, description, columns, singleUse)
@@ -83,7 +83,7 @@ func (f fakePI) CreateTabularVar(name, description string,
 	return &rainforest.Generator{}, nil
 }
 
-func (f fakePI) AddGeneratorRowsFromTable(targetGenerator *rainforest.Generator,
+func (f fakeAPI) AddGeneratorRowsFromTable(targetGenerator *rainforest.Generator,
 	targetColumns []string, rowData [][]string) error {
 	if f.addGeneratorRowsFromTable != nil {
 		return f.addGeneratorRowsFromTable(targetGenerator, targetColumns, rowData)
@@ -103,7 +103,7 @@ func TestRowUploadWorker(t *testing.T) {
 	close(inChan)
 	errorsChan := make(chan error, testBatchesCount)
 	var callCount int
-	f := fakePI{
+	f := fakeAPI{
 		addGeneratorRowsFromTable: func(targetGenerator *rainforest.Generator,
 			targetColumns []string, rowData [][]string) error {
 			if !reflect.DeepEqual(targetGenerator, gen) {
@@ -148,7 +148,7 @@ func TestRowUploadWorker_Error(t *testing.T) {
 	close(inChan)
 	errorsChan := make(chan error, testBatchesCount)
 	var callCount int
-	f := fakePI{
+	f := fakeAPI{
 		addGeneratorRowsFromTable: func(targetGenerator *rainforest.Generator,
 			targetColumns []string, rowData [][]string) error {
 			if !reflect.DeepEqual(targetGenerator, gen) {
@@ -222,7 +222,7 @@ func TestUploadTabularVar(t *testing.T) {
 		},
 	}
 	callCount := make(map[string]int)
-	f := fakePI{
+	f := fakeAPI{
 		addGeneratorRowsFromTable: func(targetGenerator *rainforest.Generator,
 			targetColumns []string, rowData [][]string) error {
 			if !reflect.DeepEqual(targetGenerator, &fakeNewGen) {
@@ -331,7 +331,7 @@ func TestUploadTabularVar_Exists_NoOverwrite(t *testing.T) {
 		},
 	}
 	callCount := make(map[string]int)
-	f := fakePI{
+	f := fakeAPI{
 		addGeneratorRowsFromTable: func(targetGenerator *rainforest.Generator,
 			targetColumns []string, rowData [][]string) error {
 			if !reflect.DeepEqual(targetGenerator, &fakeNewGen) {
@@ -433,7 +433,7 @@ func TestUploadTabularVar_Exists_Overwrite(t *testing.T) {
 		},
 	}
 	callCount := make(map[string]int)
-	f := fakePI{
+	f := fakeAPI{
 		addGeneratorRowsFromTable: func(targetGenerator *rainforest.Generator,
 			targetColumns []string, rowData [][]string) error {
 			if !reflect.DeepEqual(targetGenerator, &fakeNewGen) {
@@ -549,7 +549,7 @@ func TestCSVUpload(t *testing.T) {
 		},
 	}
 	callCount := make(map[string]int)
-	f := fakePI{
+	f := fakeAPI{
 		addGeneratorRowsFromTable: func(targetGenerator *rainforest.Generator,
 			targetColumns []string, rowData [][]string) error {
 			if !reflect.DeepEqual(targetGenerator, &fakeNewGen) {
@@ -669,7 +669,7 @@ func TestCSVUpload_MissingName(t *testing.T) {
 		},
 	}
 	callCount := make(map[string]int)
-	f := fakePI{
+	f := fakeAPI{
 		addGeneratorRowsFromTable: func(targetGenerator *rainforest.Generator,
 			targetColumns []string, rowData [][]string) error {
 			if !reflect.DeepEqual(targetGenerator, &fakeNewGen) {
@@ -781,7 +781,7 @@ func TestPreRunCSVUpload(t *testing.T) {
 		},
 	}
 	callCount := make(map[string]int)
-	f := fakePI{
+	f := fakeAPI{
 		addGeneratorRowsFromTable: func(targetGenerator *rainforest.Generator,
 			targetColumns []string, rowData [][]string) error {
 			if !reflect.DeepEqual(targetGenerator, &fakeNewGen) {
@@ -902,7 +902,7 @@ func TestPreRunCSVUpload_MissingName(t *testing.T) {
 		},
 	}
 	callCount := make(map[string]int)
-	f := fakePI{
+	f := fakeAPI{
 		addGeneratorRowsFromTable: func(targetGenerator *rainforest.Generator,
 			targetColumns []string, rowData [][]string) error {
 			if !reflect.DeepEqual(targetGenerator, &fakeNewGen) {


### PR DESCRIPTION
I missed this in #469. We fetch generators when attempting to create a new one (to know whether we should fail or overwrite, depending on whether the `--overwrite` flag is used).

Since the backend is also adding filtering by type and name to the endpoint, I added those parameters as well in order to reduce the size of the response from the backend as much as possible.