### PR TITLE
[RF-26554] Fix uploading a batch of new tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Rainforest CLI Changelog
+## 3.4.3 - 2023-02-14
+- Fix `rainforest upload` command when uploading multiple tests including at least one new test
+  - (888fe5b10cfb4e7c9acd7164fbf24a41b6c755be, @magni-)
 ## 3.4.2 - 2023-01-26
 - Narrow down query when fetching fetching generators (tabular variables)
   - (4df4734009a8c7a461bb8e0f6ee92082d91a4451, @magni-)

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ For users of CircleCI and GitHub Actions, we have platform-specific wrappers you
 ```bash
 $ docker pull gcr.io/rf-public-images/rainforest-cli
 $ docker run gcr.io/rf-public-images/rainforest-cli --version
-Rainforest CLI version 3.4.2 - build: docker
+Rainforest CLI version 3.4.3 - build: docker
 ```
 
 ### Brew

--- a/rainforest-cli.go
+++ b/rainforest-cli.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	// Version of the app in SemVer
-	version = "3.4.2"
+	version = "3.4.3"
 	// This is the default spec folder for RFML tests
 	defaultSpecFolder = "./spec/rainforest"
 )

--- a/tests.go
+++ b/tests.go
@@ -510,6 +510,7 @@ func uploadRFMLFiles(tests []*rainforest.RFTest, branchID int, localOnly bool, a
 			RFMLID:      newTest.RFMLID,
 			Description: newTest.Description,
 			Title:       newTest.Title,
+			Type:        newTest.Type,
 		}
 		err = emptyTest.PrepareToUploadFromRFML(*testIDCollection)
 		if err != nil {

--- a/tests.go
+++ b/tests.go
@@ -364,7 +364,7 @@ func uploadTests(c cliContext, api rfAPI) error {
 	}
 
 	if path := c.Args().First(); path != "" {
-		err := uploadSingleRFMLFile(path, branchID)
+		err := uploadSingleRFMLFile(path, branchID, api)
 
 		if err != nil {
 			return cli.NewExitError(err.Error(), 1)
@@ -387,7 +387,7 @@ func uploadTests(c cliContext, api rfAPI) error {
 
 // uploadSingleRFMLFile uploads RFML file syntax by
 // trying to parse the file and sending any parse errors to the caller
-func uploadSingleRFMLFile(filePath string, branchID int) error {
+func uploadSingleRFMLFile(filePath string, branchID int, api rfAPI) error {
 	// Validate first before uploading
 	err := validateSingleRFMLFile(filePath)
 	if err != nil {

--- a/tests.go
+++ b/tests.go
@@ -503,7 +503,7 @@ func uploadRFMLFiles(tests []*rainforest.RFTest, branchID int, localOnly bool, a
 	errorsChan := make(chan error)
 
 	// prepare empty tests to upload, we will fill the steps later on in case there are some
-	// dependiences between them, we want all of the IDs in place
+	// dependencies between them, we want all of the IDs in place
 	testsToCreate := make(chan *rainforest.RFTest, len(newTests))
 	for _, newTest := range newTests {
 		emptyTest := rainforest.RFTest{
@@ -527,7 +527,7 @@ func uploadRFMLFiles(tests []*rainforest.RFTest, branchID int, localOnly bool, a
 
 	// Read out the workers results
 	for i := 0; i < len(newTests); i++ {
-		if err = <-errorsChan; err != nil {
+		if err := <-errorsChan; err != nil {
 			return err
 		}
 	}
@@ -763,8 +763,7 @@ func sanitizeTestTitle(title string) string {
 	return title
 }
 
-func testCreationWorker(api rfAPI,
-	testsToCreate <-chan *rainforest.RFTest, errorsChan chan<- error) {
+func testCreationWorker(api rfAPI, testsToCreate <-chan *rainforest.RFTest, errorsChan chan<- error) {
 	for test := range testsToCreate {
 		log.Printf("Creating new test: %v", test.RFMLID)
 		err := api.CreateTest(test)
@@ -772,8 +771,7 @@ func testCreationWorker(api rfAPI,
 	}
 }
 
-func testUpdateWorker(api rfAPI,
-	testsToUpdate <-chan *rainforest.RFTest, branchID int, errorsChan chan<- error) {
+func testUpdateWorker(api rfAPI, testsToUpdate <-chan *rainforest.RFTest, branchID int, errorsChan chan<- error) {
 	for test := range testsToUpdate {
 		log.Printf("Updating existing test: %v", test.RFMLID)
 		err := api.UpdateTest(test, branchID)

--- a/tests_test.go
+++ b/tests_test.go
@@ -319,10 +319,6 @@ func TestUploadSingleTest(t *testing.T) {
 		}
 	}()
 
-	context.mappings = map[string]interface{}{
-		"test-folder": testDefaultSpecFolder,
-	}
-
 	testID := 666
 	rfmlID := "unique_rfml_id"
 	title := "a very descriptive title"
@@ -335,6 +331,7 @@ func TestUploadSingleTest(t *testing.T) {
 	}
 
 	testPath := filepath.Join(testDefaultSpecFolder, "valid_test.rfml")
+	context.args = []string{testPath}
 
 	testAPI.testIDs = []rainforest.TestIDPair{{ID: testID, RFMLID: rfmlID}}
 
@@ -422,7 +419,6 @@ func TestUploadSingleTest(t *testing.T) {
 	}
 
 	context.mappings = map[string]interface{}{
-		"test-folder": testDefaultSpecFolder,
 		"branch":      "existing-branch",
 	}
 


### PR DESCRIPTION
The backend API now requires `type` to be sent when creating a test. We added test types to the CLI in 832898b12ec58947b9710bd5d6e1231040646918, but only when uploading a single test. This wasn't caught in specs because we had no tests for uploading new tests, only for updating existing tests. I've updated the tests to cover:
- uploading a single new test
- uploading a single existing test
- uploading multiple tests (both new and existing)

The cleaner fix would be to DRY up the code between uploading a single RFML file or multiple files, but for now this is hopefully good enough.