### PR TITLE
Allow creation of temporary environment using custom-url with empty fragment

### DIFF
--- a/runner.go
+++ b/runner.go
@@ -437,7 +437,7 @@ func (r *runner) makeRunParams(c cliContext, localTests []*rainforest.RFTest, br
 		}
 
 		var environment *rainforest.Environment
-		environment, err = r.client.CreateTemporaryEnvironment(description, customURL.String(), webhookURL.String())
+		environment, err = r.client.CreateTemporaryEnvironment(description, customURLParam, webhookParam)
 		if err != nil {
 			return rainforest.RunParams{}, err
 		}


### PR DESCRIPTION
## Summary
Prior to this PR, if you passed a `custom-url` with an empty fragment e.g `https://example.com#` the `#` would be stripped off and a temporary environment with url `https://example.com` would be created instead. 

This happens because we parse the `custom-url` (see [here](https://github.com/rainforestapp/rainforest-cli/blob/d6624ff90357a64180d43e525c24650713544018/runner.go#L420)) and parsing urls like so `url.Parse(myUrl)` in golang has a [known issue](https://github.com/golang/go/issues/29603). 

The fix implemented ensures that `#` is retained in the url even if the fragment is empty.

Related issue: #473 