### PR TITLE
RF-35226 remove default tunnel id argument value

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,8 +429,9 @@ Email [help@rainforestqa.com](mailto:help@rainforestqa.com) if you're having tro
 1. Create a new Pull Request
 
 ### Testing your local changes
-First build the application:
+First, make sure you have the submodules updated, then build the application:
 ```bash
+git submodule update --init
 go build
 ```
 

--- a/direct_connect.go
+++ b/direct_connect.go
@@ -156,7 +156,7 @@ func launchDirectConnect(c cliContext, rfApi *rainforest.Client) error {
 		apiHandler(tnetWireguard, ipv4Addr, uint16(80))
 		wg.Done()
 	}()
-	log.Printf("Rainforest Direct Connect running (name: %d, PID: %d)! Press Ctrl+C to exit\n", serverDetails.Name, os.Getpid())
+	log.Printf("Rainforest Direct Connect running (name: %s, PID: %d)! Press Ctrl+C to exit\n", serverDetails.Name, os.Getpid())
 
 	wg.Wait()
 

--- a/direct_connect.go
+++ b/direct_connect.go
@@ -31,7 +31,11 @@ import (
 
 func launchDirectConnect(c cliContext, rfApi *rainforest.Client) error {
 	tunnelId := c.String("tunnel-id")
-	log.Println("Starting Direct Connect Tunnel for tunnel ID:", tunnelId)
+	if tunnelId == "" {
+		log.Println("Starting Direct Connect Tunnel")
+	} else {
+		log.Println("Starting Direct Connect Tunnel for tunnel ID:", tunnelId)
+	}
 
 	// Generate a wireguard public/private keypair
 	privateKey, err := wgtypes.GeneratePrivateKey()
@@ -152,7 +156,7 @@ func launchDirectConnect(c cliContext, rfApi *rainforest.Client) error {
 		apiHandler(tnetWireguard, ipv4Addr, uint16(80))
 		wg.Done()
 	}()
-	log.Printf("Rainforest Direct Connect running (PID: %d)! Press Ctrl+C to exit\n", os.Getpid())
+	log.Printf("Rainforest Direct Connect running (name: %d, PID: %d)! Press Ctrl+C to exit\n", serverDetails.Name, os.Getpid())
 
 	wg.Wait()
 

--- a/rainforest-cli.go
+++ b/rainforest-cli.go
@@ -639,12 +639,11 @@ func main() {
 			Name:         "direct-connect",
 			Usage:        "Start a Rainforest Direct Connect session",
 			OnUsageError: onCommandUsageErrorHandler("direct-connect"),
-			Description:  "Starts a Direct Connect Session for the given tunnel-id",
+			Description:  "Starts a Direct Connect Session",
 			Flags: []cli.Flag{
 				cli.StringFlag{
 					Name:  "tunnel-id",
 					Usage: "tunnel-id",
-					Value: "default",
 				},
 			},
 			Action: func(c *cli.Context) error {

--- a/rainforest/direct_connect.go
+++ b/rainforest/direct_connect.go
@@ -12,6 +12,7 @@ type DirectConnectConnection struct {
 	ServerPublicKey string `json:"server_public_key"`
 	ServerPort      int    `json:"server_port"`
 	ServerEndpoint  string `json:"server_endpoint"`
+	Name            string `json:"name"`
 }
 
 // SetupDirectConnectTunnel tells Rainforest to set up a Direct Connect tunnel for us


### PR DESCRIPTION
* Remove the `"default"` value for the `tunnel-id` argument for direct connect.
* Output the connection name to console when the tunnel is established.
* Add instruction to README to install submodules.

<img width="817" alt="image" src="https://github.com/user-attachments/assets/f09061ce-bf60-4b1f-8157-c69e3e3e54b1">

