### PR TITLE
RF-37622 - Use the file_key instead of the ID for download links

### DIFF
--- a/rainforest/files.go
+++ b/rainforest/files.go
@@ -22,6 +22,7 @@ type uploadedFile struct {
 	MimeType  string `json:"mime_type"`
 	Size      int64  `json:"size"`
 	Name      string `json:"name"`
+	Key       string `json:"file_key"`
 }
 
 // getUploadedFiles returns information for all all files uploaded to the
@@ -42,6 +43,7 @@ func (c *Client) getUploadedFiles(testID int) ([]uploadedFile, error) {
 type awsFileInfo struct {
 	FileID        int    `json:"file_id"`
 	FileSignature string `json:"file_signature"`
+	FileKey       string `json:"file_key"`
 	URL           string `json:"aws_url"`
 	Key           string `json:"aws_key"`
 	AccessID      string `json:"aws_access_id"`

--- a/rainforest/rfml.go
+++ b/rainforest/rfml.go
@@ -446,6 +446,7 @@ func (c *Client) ParseEmbeddedFiles(test *RFTest) error {
 				uploadedFileInfo = uploadedFile{
 					ID:        awsInfo.FileID,
 					Signature: awsInfo.FileSignature,
+					Key:       awsInfo.FileKey,
 					Digest:    fileDigest,
 				}
 				// Add to the mappings for future reference
@@ -457,7 +458,7 @@ func (c *Client) ParseEmbeddedFiles(test *RFTest) error {
 			if embed.stepVar == "screenshot" {
 				replacement = fmt.Sprintf("{{ file.screenshot(%v, %v) }}", uploadedFileInfo.ID, sig)
 			} else if embed.stepVar == "download" {
-				replacement = fmt.Sprintf("{{ file.download(%v, %v, %v) }}", uploadedFileInfo.ID, sig, filepath.Base(filePath))
+				replacement = fmt.Sprintf("{{ file.download(%v, %v, %v) }}", uploadedFileInfo.Key, sig, filepath.Base(filePath))
 			}
 
 			out = strings.Replace(out, embed.text, replacement, 1)

--- a/rainforest/rfml_test.go
+++ b/rainforest/rfml_test.go
@@ -652,8 +652,10 @@ func TestParseEmbeddedFiles(t *testing.T) {
 
 	existingDownloadID := 4321
 	existingDownloadSignature := "existing_download_signature"
+	existingDownloadKey := "c1234_t5678_1234567890abcdef"
 	newDownloadID := 7654
 	newDownloadSignature := "new_download_signature"
+	newDownloadKey := "c5678_t5678_1234567890abcdef"
 
 	// Set up fake AWS server for uploads
 	awsTestServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -676,7 +678,7 @@ func TestParseEmbeddedFiles(t *testing.T) {
 		case "GET":
 			files := []uploadedFile{
 				{ID: existingScreenshotID, Digest: screenshotDigest, Signature: existingScreenshotSignature},
-				{ID: existingDownloadID, Digest: downloadDigest, Signature: existingDownloadSignature},
+				{ID: existingDownloadID, Digest: downloadDigest, Signature: existingDownloadSignature, Key: existingDownloadKey},
 			}
 			json.NewEncoder(w).Encode(files)
 
@@ -703,6 +705,7 @@ func TestParseEmbeddedFiles(t *testing.T) {
 				awsInfo = awsFileInfo{
 					FileID:        newDownloadID,
 					FileSignature: newDownloadSignature,
+					FileKey:       newDownloadKey,
 					URL:           awsURL,
 					Key:           "key",
 					AccessID:      "accessId",
@@ -732,7 +735,7 @@ func TestParseEmbeddedFiles(t *testing.T) {
 		t.Errorf("Expected to find %v in %v", expectedStr, step.Action)
 	}
 
-	expectedStr = fmt.Sprintf("{{ file.download(%v, %v, %v) }}", existingDownloadID,
+	expectedStr = fmt.Sprintf("{{ file.download(%v, %v, %v) }}", existingDownloadKey,
 		existingDownloadSignature[0:6], filepath.Base(existingDownloadPath))
 	if !strings.Contains(step.Response, expectedStr) {
 		t.Errorf("Expected to find %v in %v", expectedStr, step.Response)
@@ -745,7 +748,7 @@ func TestParseEmbeddedFiles(t *testing.T) {
 		t.Errorf("Expected to find %v in %v", expectedStr, step.Action)
 	}
 
-	expectedStr = fmt.Sprintf("{{ file.download(%v, %v, %v) }}", newDownloadID, newDownloadSignature[0:6],
+	expectedStr = fmt.Sprintf("{{ file.download(%v, %v, %v) }}", newDownloadKey, newDownloadSignature[0:6],
 		filepath.Base(newDownloadPath))
 	if !strings.Contains(step.Response, expectedStr) {
 		t.Errorf("Expected to find %v in %v", expectedStr, step.Response)


### PR DESCRIPTION
The backend changed the way we expose files, they now need to use a specific file_key instead of the internal ID. Tested this in my staging account to verify it works properly for both newly uploaded files as well as existing matches.